### PR TITLE
fix: update rewrite integration

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
         <dependency>
             <groupId>org.openrewrite</groupId>
             <artifactId>rewrite-java</artifactId>
-            <version>8.10.0</version>
+            <version>8.30.0</version>
         </dependency>
         <dependency>
             <groupId>org.openrewrite</groupId>

--- a/src/main/java/org/shark/renovatio/application/RefactorService.java
+++ b/src/main/java/org/shark/renovatio/application/RefactorService.java
@@ -4,7 +4,8 @@ import org.openrewrite.InMemoryExecutionContext;
 import org.openrewrite.Recipe;
 import org.openrewrite.java.JavaParser;
 import org.openrewrite.SourceFile;
-import org.openrewrite.LargeSourceSet;
+import org.openrewrite.RecipeRun;
+import org.openrewrite.Result;
 import org.shark.renovatio.domain.RefactorRequest;
 import org.shark.renovatio.domain.RefactorResponse;
 import org.springframework.stereotype.Service;
@@ -23,12 +24,11 @@ public class RefactorService {
         try {
             JavaParser parser = JavaParser.fromJavaVersion().build();
             List<SourceFile> cus = parser.parse(request.getSourceCode()).collect(Collectors.toList());
-            LargeSourceSet lss = LargeSourceSet.from(cus);
-            LargeSourceSet refactoredSet = recipe.run(lss, new InMemoryExecutionContext(Throwable::printStackTrace));
+            RecipeRun run = recipe.run(cus, new InMemoryExecutionContext(Throwable::printStackTrace));
             String refactoredCode = request.getSourceCode();
-            List<SourceFile> refactoredFiles = refactoredSet.getSourceFiles();
-            if (!refactoredFiles.isEmpty()) {
-                refactoredCode = refactoredFiles.get(0).printAll();
+            List<Result> results = run.getResults();
+            if (!results.isEmpty() && results.get(0).getAfter() != null) {
+                refactoredCode = results.get(0).getAfter().printAll();
             }
             return new RefactorResponse(refactoredCode, "Refactorización exitosa");
         } catch (Exception e) {


### PR DESCRIPTION
## Summary
- fix refactor logic to use RecipeRun results instead of deprecated LargeSourceSet API
- align OpenRewrite dependencies to matching versions

## Testing
- `mvn -q -e test` *(fails: Non-resolvable parent POM for com.example:mcpserver: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b78f1d9a6c832e814fc052818ceadb