### PR TITLE
Expose OpenRewrite recipes via Swagger-documented MCP API

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -33,6 +33,11 @@
             <version>8.10.0</version>
         </dependency>
         <dependency>
+            <groupId>org.springdoc</groupId>
+            <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+            <version>2.3.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>

--- a/src/main/java/org/shark/renovatio/McpServerApplication.java
+++ b/src/main/java/org/shark/renovatio/McpServerApplication.java
@@ -1,9 +1,12 @@
 package org.shark.renovatio;
 
+import io.swagger.v3.oas.annotations.OpenAPIDefinition;
+import io.swagger.v3.oas.annotations.info.Info;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 
 @SpringBootApplication
+@OpenAPIDefinition(info = @Info(title = "Renovatio API", version = "1.0", description = "API para refactorización con OpenRewrite"))
 public class McpServerApplication {
     public static void main(String[] args) {
         SpringApplication.run(McpServerApplication.class, args);

--- a/src/main/java/org/shark/renovatio/application/McpToolingService.java
+++ b/src/main/java/org/shark/renovatio/application/McpToolingService.java
@@ -2,6 +2,8 @@ package org.shark.renovatio.application;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import org.openrewrite.config.Environment;
+import org.openrewrite.config.RecipeDescriptor;
 import org.shark.renovatio.domain.RefactorRequest;
 import org.shark.renovatio.domain.RefactorResponse;
 import org.shark.renovatio.domain.Tool;
@@ -9,8 +11,8 @@ import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
 
 import java.io.IOException;
-import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @Service
 public class McpToolingService {
@@ -25,8 +27,10 @@ public class McpToolingService {
             var resource = new ClassPathResource("mcp-tooling.json");
             JsonNode root = mapper.readTree(resource.getInputStream());
             this.spec = root.path("spec").asText();
-            Tool[] toolsArray = mapper.readValue(root.path("tools").traverse(), Tool[].class);
-            this.tools = Arrays.asList(toolsArray);
+            Environment env = Environment.builder().scanRuntimeClasspath().build();
+            this.tools = env.listRecipes().stream()
+                    .map(this::toTool)
+                    .collect(Collectors.toList());
         } catch (IOException e) {
             throw new RuntimeException("No se pudo leer mcp-tooling.json", e);
         }
@@ -40,10 +44,16 @@ public class McpToolingService {
         return tools;
     }
 
+    private Tool toTool(RecipeDescriptor descriptor) {
+        Tool tool = new Tool();
+        tool.setName(descriptor.getName());
+        tool.setDescription(descriptor.getDisplayName());
+        tool.setCommand("openrewrite");
+        return tool;
+    }
+
     public RefactorResponse runTool(String name, RefactorRequest request) {
-        if ("openrewrite".equalsIgnoreCase(name)) {
-            return refactorService.refactorCode(request);
-        }
-        return new RefactorResponse(request.getSourceCode(), "Tool no soportado: " + name);
+        request.setRecipe(name);
+        return refactorService.refactorCode(request);
     }
 }

--- a/src/main/java/org/shark/renovatio/domain/RefactorRequest.java
+++ b/src/main/java/org/shark/renovatio/domain/RefactorRequest.java
@@ -1,7 +1,12 @@
 package org.shark.renovatio.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Petición para refactorizar código")
 public class RefactorRequest {
+    @Schema(description = "Código fuente a refactorizar")
     private String sourceCode;
+    @Schema(description = "Nombre de la receta de OpenRewrite a ejecutar")
     private String recipe;
 
     public String getSourceCode() {

--- a/src/main/java/org/shark/renovatio/domain/RefactorResponse.java
+++ b/src/main/java/org/shark/renovatio/domain/RefactorResponse.java
@@ -1,7 +1,12 @@
 package org.shark.renovatio.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Respuesta tras la refactorización")
 public class RefactorResponse {
+    @Schema(description = "Código resultante luego de aplicar la receta")
     private String refactoredCode;
+    @Schema(description = "Mensaje con el resultado de la operación")
     private String message;
 
     public RefactorResponse() {}

--- a/src/main/java/org/shark/renovatio/domain/Tool.java
+++ b/src/main/java/org/shark/renovatio/domain/Tool.java
@@ -1,8 +1,14 @@
 package org.shark.renovatio.domain;
 
+import io.swagger.v3.oas.annotations.media.Schema;
+
+@Schema(description = "Definición de una herramienta MCP")
 public class Tool {
+    @Schema(description = "Nombre único de la herramienta")
     private String name;
+    @Schema(description = "Descripción de la herramienta")
     private String description;
+    @Schema(description = "Comando asociado")
     private String command;
 
     public String getName() {

--- a/src/main/java/org/shark/renovatio/infrastructure/McpController.java
+++ b/src/main/java/org/shark/renovatio/infrastructure/McpController.java
@@ -1,5 +1,7 @@
 package org.shark.renovatio.infrastructure;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.shark.renovatio.application.McpToolingService;
 import org.shark.renovatio.domain.RefactorRequest;
 import org.shark.renovatio.domain.RefactorResponse;
@@ -11,22 +13,26 @@ import java.util.List;
 
 @RestController
 @RequestMapping("/mcp")
+@Tag(name = "MCP")
 public class McpController {
 
     @Autowired
     private McpToolingService mcpToolingService;
 
     @GetMapping("/spec")
+    @Operation(summary = "Obtiene la especificación MCP")
     public String getSpec() {
         return mcpToolingService.getSpec();
     }
 
     @GetMapping("/tools")
+    @Operation(summary = "Lista las herramientas disponibles")
     public List<Tool> listTools() {
         return mcpToolingService.getTools();
     }
 
     @PostMapping("/run/{toolName}")
+    @Operation(summary = "Ejecuta una herramienta específica")
     public RefactorResponse runTool(@PathVariable String toolName, @RequestBody RefactorRequest request) {
         return mcpToolingService.runTool(toolName, request);
     }

--- a/src/main/java/org/shark/renovatio/infrastructure/RefactorController.java
+++ b/src/main/java/org/shark/renovatio/infrastructure/RefactorController.java
@@ -1,5 +1,7 @@
 package org.shark.renovatio.infrastructure;
 
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import org.shark.renovatio.domain.RefactorRequest;
 import org.shark.renovatio.domain.RefactorResponse;
 import org.shark.renovatio.application.RefactorService;
@@ -8,11 +10,13 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/refactor")
+@Tag(name = "Refactor")
 public class RefactorController {
     @Autowired
     private RefactorService refactorService;
 
     @PostMapping
+    @Operation(summary = "Refactoriza código Java usando OpenRewrite")
     public RefactorResponse refactor(@RequestBody RefactorRequest request) {
         return refactorService.refactorCode(request);
     }


### PR DESCRIPTION
## Summary
- add springdoc-openapi support and OpenAPI definition for Renovatio API
- expose all OpenRewrite recipes as MCP tools and run them by name
- document refactor endpoints and domain models with Swagger annotations

## Testing
- `mvn -q -e test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b82853adb0832e8797acfc70cd3ee1