### PR TITLE
Add basic MCP ping and restart handlers

### DIFF
--- a/src/main/java/org/shark/renovatio/infrastructure/McpProtocolController.java
+++ b/src/main/java/org/shark/renovatio/infrastructure/McpProtocolController.java
@@ -25,12 +25,18 @@ public class McpProtocolController {
             switch (request.getMethod()) {
                 case "initialize":
                     return handleInitialize(request);
+                case "ping":
+                    return handlePing(request);
+                case "restart":
+                    return handleRestart(request);
+                case "shutdown":
+                    return handleShutdown(request);
                 case "tools/list":
                     return handleToolsList(request);
                 case "tools/call":
                     return handleToolsCall(request);
                 default:
-                    return new McpResponse(request.getId(), 
+                    return new McpResponse(request.getId(),
                         new McpError(-32601, "Method not found: " + request.getMethod()));
             }
         } catch (Exception e) {
@@ -47,6 +53,22 @@ public class McpProtocolController {
             "name", "Renovatio OpenRewrite MCP Server",
             "version", "1.0.0"
         ));
+        return new McpResponse(request.getId(), result);
+    }
+
+    private McpResponse handlePing(McpRequest request) {
+        return new McpResponse(request.getId(), new HashMap<>());
+    }
+
+    private McpResponse handleRestart(McpRequest request) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("message", "Server restart requested");
+        return new McpResponse(request.getId(), result);
+    }
+
+    private McpResponse handleShutdown(McpRequest request) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("message", "Server shutdown requested");
         return new McpResponse(request.getId(), result);
     }
 

--- a/test-mcp-server.sh
+++ b/test-mcp-server.sh
@@ -25,10 +25,34 @@ else
   echo "❌ MCP Initialize: FAILED"
 fi
 
-# Test 2: List tools
-echo "2. Testing tools list..."
+# Test 2: Ping
+echo "2. Testing MCP ping..."
+PING_RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": "2", "method": "ping", "params": {}}' \
+  http://localhost:8080/)
+
+if echo "$PING_RESPONSE" | jq -e '.result' > /dev/null; then
+  echo "✅ MCP Ping: SUCCESS"
+else
+  echo "❌ MCP Ping: FAILED"
+fi
+
+# Test 3: Restart
+echo "3. Testing MCP restart..."
+RESTART_RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": "3", "method": "restart", "params": {}}' \
+  http://localhost:8080/)
+
+if echo "$RESTART_RESPONSE" | jq -e '.result.message' > /dev/null; then
+  echo "✅ MCP Restart: SUCCESS"
+else
+  echo "❌ MCP Restart: FAILED"
+fi
+
+# Test 4: List tools
+echo "4. Testing tools list..."
 TOOLS_RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": "2", "method": "tools/list", "params": {}}' \
+  -d '{"jsonrpc": "2.0", "id": "4", "method": "tools/list", "params": {}}' \
   http://localhost:8080/)
 
 TOOLS_COUNT=$(echo "$TOOLS_RESPONSE" | jq '.result.tools | length')
@@ -38,10 +62,10 @@ else
   echo "❌ Tools List: FAILED"
 fi
 
-# Test 3: Execute AutoFormat tool
-echo "3. Testing AutoFormat tool execution..."
+# Test 5: Execute AutoFormat tool
+echo "5. Testing AutoFormat tool execution..."
 FORMAT_RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": "3", "method": "tools/call", "params": {"name": "org.openrewrite.java.format.AutoFormat", "arguments": {"sourceCode": "public class Test{private int x=0;}"}}}' \
+  -d '{"jsonrpc": "2.0", "id": "5", "method": "tools/call", "params": {"name": "org.openrewrite.java.format.AutoFormat", "arguments": {"sourceCode": "public class Test{private int x=0;}"}}}' \
   http://localhost:8080/)
 
 if echo "$FORMAT_RESPONSE" | jq -e '.result.content.text' > /dev/null; then
@@ -50,10 +74,10 @@ else
   echo "❌ AutoFormat Tool: FAILED"
 fi
 
-# Test 4: Execute ExplicitInitialization tool
-echo "4. Testing ExplicitInitialization tool execution..."
+# Test 6: Execute ExplicitInitialization tool
+echo "6. Testing ExplicitInitialization tool execution..."
 INIT_RESPONSE=$(curl -s -X POST -H "Content-Type: application/json" \
-  -d '{"jsonrpc": "2.0", "id": "4", "method": "tools/call", "params": {"name": "org.openrewrite.java.cleanup.ExplicitInitialization", "arguments": {"sourceCode": "public class Test { private String name = null; private int count = 0; }"}}}' \
+  -d '{"jsonrpc": "2.0", "id": "6", "method": "tools/call", "params": {"name": "org.openrewrite.java.cleanup.ExplicitInitialization", "arguments": {"sourceCode": "public class Test { private String name = null; private int count = 0; }"}}}' \
   http://localhost:8080/)
 
 if echo "$INIT_RESPONSE" | jq -e '.result.content.text' > /dev/null; then
@@ -64,8 +88,8 @@ fi
 
 echo "🔍 Testing REST API Endpoints..."
 
-# Test 5: REST API tools list
-echo "5. Testing REST API tools list..."
+# Test 7: REST API tools list
+echo "7. Testing REST API tools list..."
 REST_TOOLS=$(curl -s http://localhost:8080/mcp/tools | jq '. | length')
 if [ "$REST_TOOLS" -gt 15 ]; then
   echo "✅ REST Tools List: SUCCESS ($REST_TOOLS tools found)"
@@ -73,8 +97,8 @@ else
   echo "❌ REST Tools List: FAILED"
 fi
 
-# Test 6: REST API refactor
-echo "6. Testing REST API refactor..."
+# Test 8: REST API refactor
+echo "8. Testing REST API refactor..."
 REST_REFACTOR=$(curl -s -X POST -H "Content-Type: application/json" \
   -d '{"sourceCode": "public class Test { private String name = null; }", "recipe": "org.openrewrite.java.cleanup.ExplicitInitialization"}' \
   http://localhost:8080/api/refactor)
@@ -85,8 +109,8 @@ else
   echo "❌ REST Refactor: FAILED"
 fi
 
-# Test 7: Swagger UI accessibility
-echo "7. Testing Swagger UI..."
+# Test 9: Swagger UI accessibility
+echo "9. Testing Swagger UI..."
 SWAGGER_STATUS=$(curl -s -o /dev/null -w "%{http_code}" http://localhost:8080/swagger-ui/index.html)
 if [ "$SWAGGER_STATUS" = "200" ]; then
   echo "✅ Swagger UI: SUCCESS"


### PR DESCRIPTION
## Summary
- add ping, restart and shutdown handling to the MCP protocol controller
- extend test script with ping and restart checks

## Testing
- `bash test-mcp-server.sh` *(fails: Non-resolvable parent POM for com.example:mcpserver due to network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68b8bdb931c8832eb09c2017091e8ffb