### PR TITLE
feat: expose CLI manifest endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,6 +172,48 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:8181/
 ```
 
+#### Obtener Manifiesto CLI
+Permite a clientes CLI generar subcomandos automáticamente.
+
+```bash
+curl -X POST -H "Content-Type: application/json" \
+  -d '{"jsonrpc": "2.0", "id": "5", "method": "cli/manifest", "params": {}}' \
+  http://localhost:8181/
+```
+
+La respuesta incluye un objeto `commands` con elementos que exponen los campos `name`, `description` e `inputSchema`:
+
+```json
+{
+  "jsonrpc": "2.0",
+  "id": "5",
+  "result": {
+    "commands": [
+      {
+        "name": "org.openrewrite.java.format.AutoFormat",
+        "description": "Automatically format Java code",
+        "inputSchema": {
+          "type": "object",
+          "properties": {
+            "sourceCode": {
+              "type": "string",
+              "description": "Java source code to refactor"
+            },
+            "projectPath": {
+              "type": "string",
+              "description": "Path to the project (optional)"
+            }
+          },
+          "required": ["sourceCode"]
+        }
+      }
+    ]
+  }
+}
+```
+
+Los clientes pueden iterar sobre `commands` y utilizar cada `name`, `description` e `inputSchema` para generar subcomandos CLI.
+
 #### Ejecutar Herramienta Java (OpenRewrite)
 ```bash
 curl -X POST -H "Content-Type: application/json" \

--- a/src/main/java/org/shark/renovatio/infrastructure/McpProtocolController.java
+++ b/src/main/java/org/shark/renovatio/infrastructure/McpProtocolController.java
@@ -58,6 +58,8 @@ public class McpProtocolController {
                     return handleResourcesList(request);
                 case "resources/read":
                     return handleResourcesRead(request);
+                case "cli/manifest":
+                    return handleCliManifest(request);
                 default:
                     return new McpResponse(request.getId(),
                         new McpError(-32601, "Method not found: " + request.getMethod()));
@@ -98,6 +100,12 @@ public class McpProtocolController {
     private McpResponse handleToolsList(McpRequest request) {
         Map<String, Object> result = new HashMap<>();
         result.put("tools", mcpToolingService.getMcpTools());
+        return new McpResponse(request.getId(), result);
+    }
+
+    private McpResponse handleCliManifest(McpRequest request) {
+        Map<String, Object> result = new HashMap<>();
+        result.put("commands", mcpToolingService.getMcpTools());
         return new McpResponse(request.getId(), result);
     }
 


### PR DESCRIPTION
## Summary
- support `cli/manifest` in MCP controller
- return available commands for CLI tooling
- document CLI manifest JSON structure

## Testing
- `mvn -q test` *(fails: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bc428dba38832e87c42f16abea4fe3