### PR TITLE
Add COBOL copybook migration tooling

### DIFF
--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
@@ -48,13 +48,15 @@ public class CobolProviderConfiguration {
             JavaGenerationService javaGenerationService,
             MigrationPlanService migrationPlanService,
             IndexingService indexingService,
-            MetricsService metricsService) {
+            MetricsService metricsService,
+            TemplateCodeGenerationService templateCodeGenerationService) {
         return new CobolLanguageProvider(
             parsingService,
             javaGenerationService,
             migrationPlanService,
             indexingService,
-            metricsService
+            metricsService,
+            templateCodeGenerationService
         );
     }
 }

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java
@@ -10,6 +10,9 @@ import java.io.StringReader;
 import java.io.StringWriter;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Locale;
 
 /**
  * Template-based code generation service using Freemarker
@@ -257,5 +260,94 @@ public class TemplateCodeGenerationService {
         StringWriter writer = new StringWriter();
         template.process(templateData, writer);
         return writer.toString();
+    }
+
+    /**
+     * Generate a set of Java artifacts (service, DTO, controller and mapper)
+     * from a parsed copybook structure.
+     */
+    public Map<String, String> generateFromCopybook(String copybookName, Map<String, Object> metadata)
+            throws IOException, TemplateException {
+        String baseName = toPascalCase(copybookName);
+        Map<String, String> generated = new HashMap<>();
+
+        // Service class
+        Map<String, Object> serviceData = new HashMap<>();
+        serviceData.put("programName", baseName);
+        serviceData.put("fileName", metadata.getOrDefault("filePath", copybookName));
+        serviceData.put("className", baseName + "Service");
+        serviceData.put("dataItems", metadata.get("dataItems"));
+        serviceData.put("businessRules", List.of());
+        serviceData.put("validationRules", List.of());
+        generated.put(baseName + "Service.java", generateServiceClass(serviceData));
+
+        // DTO class
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> items = (List<Map<String, Object>>) metadata.get("dataItems");
+        List<Map<String, Object>> fields = new ArrayList<>();
+        if (items != null) {
+            for (Map<String, Object> item : items) {
+                String cobolName = (String) item.get("name");
+                Map<String, Object> field = new HashMap<>();
+                field.put("level", item.get("level"));
+                field.put("cobolName", cobolName);
+                field.put("picture", item.get("picture"));
+                field.put("javaName", toCamelCase(cobolName));
+                field.put("javaType", mapPictureToJavaType((String) item.get("picture")));
+                fields.add(field);
+            }
+        }
+        Map<String, Object> dtoData = new HashMap<>();
+        dtoData.put("programName", baseName);
+        dtoData.put("className", baseName + "DTO");
+        dtoData.put("fields", fields);
+        generated.put(baseName + "DTO.java", generateDtoClass(dtoData));
+
+        // REST controller
+        Map<String, Object> controllerData = new HashMap<>();
+        controllerData.put("programName", baseName);
+        controllerData.put("className", baseName);
+        controllerData.put("serviceName", baseName + "Service");
+        controllerData.put("requestName", baseName + "Request");
+        controllerData.put("responseName", baseName + "Response");
+        generated.put(baseName + "Controller.java", generateRestController(controllerData));
+
+        // Mapper
+        Map<String, Object> mapperData = new HashMap<>();
+        mapperData.put("programName", baseName);
+        mapperData.put("className", baseName + "Mapper");
+        mapperData.put("sourceClass", baseName + "DTO");
+        mapperData.put("targetClass", baseName + "Entity");
+        mapperData.put("mappings", List.of());
+        generated.put(baseName + "Mapper.java", generateMapper(mapperData));
+
+        return generated;
+    }
+
+    private String toPascalCase(String text) {
+        if (text == null || text.isEmpty()) return "";
+        String[] parts = text.toLowerCase(Locale.ROOT).split("[^a-z0-9]");
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) continue;
+            sb.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+        }
+        return sb.toString();
+    }
+
+    private String toCamelCase(String text) {
+        String pascal = toPascalCase(text);
+        if (pascal.isEmpty()) return pascal;
+        return Character.toLowerCase(pascal.charAt(0)) + pascal.substring(1);
+    }
+
+    private String mapPictureToJavaType(String picture) {
+        if (picture == null) {
+            return "String";
+        }
+        if (picture.contains("9")) {
+            return "Integer";
+        }
+        return "String";
     }
 }

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/CopybookMigrationToolTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/CopybookMigrationToolTest.java
@@ -1,0 +1,48 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.provider.cobol.CobolLanguageProvider;
+import org.shark.renovatio.provider.cobol.infrastructure.CobolMcpToolsProvider;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class CopybookMigrationToolTest {
+
+    @Test
+    void migrateCopybookGeneratesArtifacts() throws Exception {
+        Path temp = Files.createTempDirectory("cobol-copybook");
+        String copybook = "       01 CUSTOMER-REC.\n" +
+                "          05 CUSTOMER-ID PIC X(10).\n" +
+                "          05 CUSTOMER-AGE PIC 9(3).";
+        Path copybookFile = temp.resolve("CUSTOMER.cpy");
+        Files.writeString(copybookFile, copybook);
+
+        CobolParsingService parsingService = new CobolParsingService();
+        JavaGenerationService javaGenerationService = new JavaGenerationService(parsingService);
+        TemplateCodeGenerationService templateService = new TemplateCodeGenerationService();
+        MigrationPlanService migrationPlanService = new MigrationPlanService(parsingService, javaGenerationService);
+        IndexingService indexingService = new IndexingService();
+        MetricsService metricsService = new MetricsService();
+        CobolLanguageProvider provider = new CobolLanguageProvider(
+                parsingService, javaGenerationService, migrationPlanService,
+                indexingService, metricsService, templateService);
+        CobolMcpToolsProvider tools = new CobolMcpToolsProvider(provider);
+
+        Map<String, Object> args = Map.of(
+                "workspacePath", temp.toString(),
+                "copybook", "CUSTOMER.cpy"
+        );
+
+        Object result = tools.executeCobolTool("cobol.copybook.migrate", args);
+        assertTrue(result instanceof Map);
+        Map<?,?> resMap = (Map<?,?>) result;
+        assertEquals(true, resMap.get("success"));
+        Map<?,?> files = (Map<?,?>) resMap.get("files");
+        assertTrue(files.containsKey("CustomerDTO.java"));
+        assertTrue(files.containsKey("CustomerService.java"));
+    }
+}


### PR DESCRIPTION
## Summary
- support locating and parsing COBOL copybooks
- generate service, DTO and other Java artifacts from copybooks using templates
- expose `cobol.copybook.migrate` MCP tool and add coverage tests

## Testing
- `mvn -q -pl renovatio-provider-cobol -am test` *(fails: Non-resolvable parent POM: Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68bee7f8afc8832e9d5a0b0dc3c0cae8