### PR TITLE
feat: add migration reporting with role-based access

### DIFF
--- a/renovatio-core/pom.xml
+++ b/renovatio-core/pom.xml
@@ -36,5 +36,11 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+
+        <dependency>
+            <groupId>org.apache.pdfbox</groupId>
+            <artifactId>pdfbox</artifactId>
+            <version>2.0.30</version>
+        </dependency>
     </dependencies>
 </project>

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/infrastructure/ReportController.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/infrastructure/ReportController.java
@@ -1,0 +1,57 @@
+package org.shark.renovatio.core.infrastructure;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.shark.renovatio.core.service.MigrationReportService;
+import org.shark.renovatio.core.service.ReportAccessService;
+import org.shark.renovatio.shared.domain.AccessRole;
+import org.shark.renovatio.shared.domain.MigrationReport;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * REST controller exposing report endpoints.
+ */
+@RestController
+@RequestMapping("/reports")
+@Tag(name = "Reports")
+public class ReportController {
+    private final MigrationReportService reportService;
+    private final ReportAccessService accessService;
+
+    public ReportController(MigrationReportService reportService, ReportAccessService accessService) {
+        this.reportService = reportService;
+        this.accessService = accessService;
+    }
+
+    @GetMapping(value = "/html", produces = MediaType.TEXT_HTML_VALUE)
+    @Operation(summary = "Get migration report in HTML format")
+    public ResponseEntity<String> getHtmlReport(@RequestHeader(value = "X-Role", required = false) String roleHeader) {
+        AccessRole role = AccessRole.fromString(roleHeader);
+        if (!accessService.canView(role)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        MigrationReport report = reportService.aggregateReport();
+        return ResponseEntity.ok(reportService.renderHtml(report));
+    }
+
+    @GetMapping(value = "/pdf", produces = MediaType.APPLICATION_PDF_VALUE)
+    @Operation(summary = "Get migration report in PDF format")
+    public ResponseEntity<byte[]> getPdfReport(@RequestHeader(value = "X-Role", required = false) String roleHeader) {
+        AccessRole role = AccessRole.fromString(roleHeader);
+        if (!accessService.canView(role)) {
+            return ResponseEntity.status(HttpStatus.FORBIDDEN).build();
+        }
+        MigrationReport report = reportService.aggregateReport();
+        byte[] pdf = reportService.renderPdf(report);
+        return ResponseEntity.ok()
+                .header(HttpHeaders.CONTENT_DISPOSITION, "attachment; filename=report.pdf")
+                .body(pdf);
+    }
+}

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/service/MigrationReportService.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/service/MigrationReportService.java
@@ -1,0 +1,95 @@
+package org.shark.renovatio.core.service;
+
+import org.shark.renovatio.shared.domain.MigrationReport;
+import org.shark.renovatio.shared.domain.Scope;
+import org.shark.renovatio.shared.domain.Workspace;
+import org.shark.renovatio.shared.domain.MetricsResult;
+import org.shark.renovatio.shared.spi.LanguageProvider;
+import org.springframework.stereotype.Service;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.List;
+
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.pdmodel.PDPage;
+import org.apache.pdfbox.pdmodel.PDPageContentStream;
+import org.apache.pdfbox.pdmodel.font.PDType1Font;
+
+/**
+ * Service that aggregates metrics and renders reports in different formats.
+ */
+@Service
+public class MigrationReportService {
+    private final LanguageProviderRegistry registry;
+
+    public MigrationReportService(LanguageProviderRegistry registry) {
+        this.registry = registry;
+    }
+
+    /**
+     * Aggregate metrics and statuses from all registered providers.
+     */
+    public MigrationReport aggregateReport() {
+        MigrationReport report = new MigrationReport();
+        Scope scope = new Scope();
+        Workspace workspace = new Workspace("report", ".", "main");
+        List<LanguageProvider> providers = registry.getAllProviders();
+        for (LanguageProvider provider : providers) {
+            MetricsResult metrics = provider.metrics(scope, workspace);
+            report.addStatus(provider.language(), metrics.isSuccess());
+            report.addMetrics(metrics.getMetrics());
+        }
+        return report;
+    }
+
+    /**
+     * Render report as HTML string.
+     */
+    public String renderHtml(MigrationReport report) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("<html><body><h1>Migration Report</h1>");
+        sb.append("<h2>Statuses</h2><ul>");
+        report.getStatuses().forEach((k, v) ->
+            sb.append("<li>").append(k).append(": ").append(v).append("</li>"));
+        sb.append("</ul><h2>Metrics</h2><ul>");
+        report.getMetrics().forEach((k, v) ->
+            sb.append("<li>").append(k).append(": ").append(String.format("%.2f", v)).append("</li>"));
+        sb.append("</ul></body></html>");
+        return sb.toString();
+    }
+
+    /**
+     * Render report as PDF bytes.
+     */
+    public byte[] renderPdf(MigrationReport report) {
+        try (PDDocument doc = new PDDocument()) {
+            PDPage page = new PDPage();
+            doc.addPage(page);
+            try (PDPageContentStream content = new PDPageContentStream(doc, page)) {
+                content.beginText();
+                content.setFont(PDType1Font.HELVETICA, 12);
+                content.newLineAtOffset(50, 750);
+                content.showText("Migration Report");
+                content.newLineAtOffset(0, -20);
+                content.showText("Statuses:");
+                for (var entry : report.getStatuses().entrySet()) {
+                    content.newLineAtOffset(0, -15);
+                    content.showText(entry.getKey() + ": " + entry.getValue());
+                }
+                content.newLineAtOffset(0, -20);
+                content.showText("Metrics:");
+                for (var entry : report.getMetrics().entrySet()) {
+                    content.newLineAtOffset(0, -15);
+                    content.showText(entry.getKey() + ": " + String.format("%.2f", entry.getValue()));
+                }
+                content.endText();
+            }
+            ByteArrayOutputStream out = new ByteArrayOutputStream();
+            doc.save(out);
+            return out.toByteArray();
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to render PDF", e);
+        }
+    }
+}

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/service/ReportAccessService.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/service/ReportAccessService.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.core.service;
+
+import org.shark.renovatio.shared.domain.AccessRole;
+import org.springframework.stereotype.Service;
+
+import java.util.EnumSet;
+import java.util.Set;
+
+/**
+ * Simple access control service for report viewing.
+ */
+@Service
+public class ReportAccessService {
+    private final Set<AccessRole> allowedRoles = EnumSet.of(AccessRole.ADMIN, AccessRole.MANAGER);
+
+    /**
+     * Check if the given role can view reports.
+     */
+    public boolean canView(AccessRole role) {
+        return role != null && allowedRoles.contains(role);
+    }
+}

--- a/renovatio-core/src/test/java/org/shark/renovatio/core/service/MigrationReportServiceTest.java
+++ b/renovatio-core/src/test/java/org/shark/renovatio/core/service/MigrationReportServiceTest.java
@@ -1,0 +1,65 @@
+package org.shark.renovatio.core.service;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.shared.domain.*;
+import org.shark.renovatio.shared.spi.LanguageProvider;
+
+import java.util.EnumSet;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class MigrationReportServiceTest {
+
+    @Test
+    void aggregatesMetricsAndRenders() {
+        LanguageProviderRegistry registry = new LanguageProviderRegistry();
+        registry.registerProvider(new StubProvider());
+
+        MigrationReportService service = new MigrationReportService(registry);
+        MigrationReport report = service.aggregateReport();
+
+        assertEquals("SUCCESS", report.getStatuses().get("stub"));
+        assertEquals(10.0, report.getMetrics().get("linesOfCode"));
+
+        String html = service.renderHtml(report);
+        assertTrue(html.contains("linesOfCode"));
+
+        byte[] pdf = service.renderPdf(report);
+        assertTrue(pdf.length > 0);
+    }
+
+    static class StubProvider implements LanguageProvider {
+        @Override
+        public String language() { return "stub"; }
+
+        @Override
+        public Set<Capabilities> capabilities() {
+            return EnumSet.of(Capabilities.METRICS);
+        }
+
+        @Override
+        public AnalyzeResult analyze(NqlQuery query, Workspace workspace) { return new AnalyzeResult(true, ""); }
+
+        @Override
+        public PlanResult plan(NqlQuery query, Scope scope, Workspace workspace) { return new PlanResult(true, ""); }
+
+        @Override
+        public ApplyResult apply(String planId, boolean dryRun, Workspace workspace) { return new ApplyResult(true, ""); }
+
+        @Override
+        public DiffResult diff(String runId, Workspace workspace) { return new DiffResult(true, ""); }
+
+        @Override
+        public Optional<StubResult> generateStubs(NqlQuery query, Workspace workspace) { return Optional.empty(); }
+
+        @Override
+        public MetricsResult metrics(Scope scope, Workspace workspace) {
+            MetricsResult r = new MetricsResult(true, "ok");
+            r.setMetrics(Map.of("linesOfCode", 10));
+            return r;
+        }
+    }
+}

--- a/renovatio-core/src/test/java/org/shark/renovatio/core/service/ReportAccessServiceTest.java
+++ b/renovatio-core/src/test/java/org/shark/renovatio/core/service/ReportAccessServiceTest.java
@@ -1,0 +1,17 @@
+package org.shark.renovatio.core.service;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.shared.domain.AccessRole;
+import static org.junit.jupiter.api.Assertions.*;
+
+class ReportAccessServiceTest {
+
+    @Test
+    void testRoleAccess() {
+        ReportAccessService service = new ReportAccessService();
+        assertTrue(service.canView(AccessRole.ADMIN));
+        assertTrue(service.canView(AccessRole.MANAGER));
+        assertFalse(service.canView(AccessRole.VIEWER));
+        assertFalse(service.canView(null));
+    }
+}

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/domain/AccessRole.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/domain/AccessRole.java
@@ -1,0 +1,24 @@
+package org.shark.renovatio.shared.domain;
+
+/**
+ * Roles used for accessing generated reports.
+ */
+public enum AccessRole {
+    ADMIN,
+    MANAGER,
+    VIEWER;
+
+    /**
+     * Parse a string to an AccessRole. Returns null if the role is invalid.
+     */
+    public static AccessRole fromString(String role) {
+        if (role == null) {
+            return null;
+        }
+        try {
+            return AccessRole.valueOf(role.toUpperCase());
+        } catch (IllegalArgumentException ex) {
+            return null;
+        }
+    }
+}

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/domain/MigrationReport.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/domain/MigrationReport.java
@@ -1,0 +1,37 @@
+package org.shark.renovatio.shared.domain;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Aggregated report containing migration metrics and provider statuses.
+ */
+public class MigrationReport {
+    private final Map<String, Double> metrics = new HashMap<>();
+    private final Map<String, String> statuses = new HashMap<>();
+
+    /**
+     * Add metrics from a provider to the aggregate.
+     */
+    public void addMetrics(Map<String, ? extends Number> data) {
+        if (data == null) {
+            return;
+        }
+        data.forEach((k, v) -> metrics.merge(k, v.doubleValue(), Double::sum));
+    }
+
+    /**
+     * Record the status for a provider.
+     */
+    public void addStatus(String provider, boolean success) {
+        statuses.put(provider, success ? "SUCCESS" : "FAILED");
+    }
+
+    public Map<String, Double> getMetrics() {
+        return metrics;
+    }
+
+    public Map<String, String> getStatuses() {
+        return statuses;
+    }
+}


### PR DESCRIPTION
## Summary
- aggregate provider metrics into unified MigrationReport
- render PDF/HTML reports and expose report endpoints
- gate report visibility with role-based access controls

## Testing
- `mvn -q -pl renovatio-shared,renovatio-core -am test` *(fails: Non-resolvable parent POM due to network unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bf58c05d44832ea5ede9e0108201b0