### PR TITLE
Add COBOL DB2 migration tool

### DIFF
--- a/renovatio-provider-cobol/README.md
+++ b/renovatio-provider-cobol/README.md
@@ -119,6 +119,13 @@ Creates a migration plan for COBOL to Java transformation.
 - `migrationStrategy`: Migration strategy (full, incremental, hybrid)
 - `targetFramework`: Target Java framework
 
+### `cobol.db2.migrate`
+Generates JPA entity and repository classes from embedded DB2 `EXEC SQL` blocks.
+
+**Parameters:**
+- `workspacePath` (required): Path to COBOL workspace
+- `program` (required): COBOL program file containing SQL statements
+
 ### `cobol.migration.apply`
 Applies a migration plan to transform COBOL to Java.
 

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolMcpToolsProvider.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolMcpToolsProvider.java
@@ -34,6 +34,7 @@ public class CobolMcpToolsProvider {
         tools.add(createCalculateMetricsTool());
         tools.add(createGenerateDiffTool());
         tools.add(createCopybookMigrationTool());
+        tools.add(createDb2MigrationTool());
         
         return tools;
     }
@@ -50,8 +51,26 @@ public class CobolMcpToolsProvider {
             case "cobol.metrics" -> executeMetricsTool(arguments);
             case "cobol.diff" -> executeDiffTool(arguments);
             case "cobol.copybook.migrate" -> executeCopybookMigrationTool(arguments);
+            case "cobol.db2.migrate" -> executeDb2MigrationTool(arguments);
             default -> Map.of("error", "Unknown COBOL tool: " + toolName);
         };
+    }
+
+    private CobolMcpTool createDb2MigrationTool() {
+        CobolMcpTool tool = new CobolMcpTool();
+        tool.setName("cobol.db2.migrate");
+        tool.setDescription("Generate JPA code from embedded DB2 EXEC SQL statements");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", Map.of(
+                "workspacePath", Map.of("type", "string", "description", "Path to COBOL workspace"),
+                "program", Map.of("type", "string", "description", "COBOL program file")
+        ));
+        schema.put("required", List.of("workspacePath", "program"));
+
+        tool.setInputSchema(schema);
+        return tool;
     }
     
     private CobolMcpTool createAnalyzeCobolTool() {
@@ -387,6 +406,35 @@ public class CobolMcpToolsProvider {
                 "success", result.isSuccess(),
                 "message", result.getMessage(),
                 "files", result.getGeneratedCode()
+            );
+        } catch (Exception e) {
+            return Map.of("success", false, "error", e.getMessage());
+        }
+    }
+
+    private Object executeDb2MigrationTool(Map<String, Object> arguments) {
+        try {
+            String workspacePath = (String) arguments.get("workspacePath");
+            String program = (String) arguments.get("program");
+
+            Workspace workspace = new Workspace();
+            workspace.setId("mcp-" + System.currentTimeMillis());
+            workspace.setPath(workspacePath);
+            workspace.setBranch("main");
+
+            NqlQuery query = new NqlQuery();
+            query.setType(NqlQuery.QueryType.FIND);
+            query.setTarget("db2");
+            query.setLanguage("cobol");
+            Map<String, Object> params = new HashMap<>();
+            params.put("program", program);
+            query.setParameters(params);
+
+            StubResult result = cobolProvider.migrateDb2(query, workspace);
+            return Map.of(
+                    "success", result.isSuccess(),
+                    "message", result.getMessage(),
+                    "files", result.getGeneratedCode()
             );
         } catch (Exception e) {
             return Map.of("success", false, "error", e.getMessage());

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
@@ -41,6 +41,11 @@ public class CobolProviderConfiguration {
     public MetricsService metricsService() {
         return new MetricsService();
     }
+
+    @Bean
+    public Db2MigrationService db2MigrationService(CobolParsingService parsingService) {
+        return new Db2MigrationService(parsingService);
+    }
     
     @Bean
     public CobolLanguageProvider cobolLanguageProvider(
@@ -49,14 +54,16 @@ public class CobolProviderConfiguration {
             MigrationPlanService migrationPlanService,
             IndexingService indexingService,
             MetricsService metricsService,
-            TemplateCodeGenerationService templateCodeGenerationService) {
+            TemplateCodeGenerationService templateCodeGenerationService,
+            Db2MigrationService db2MigrationService) {
         return new CobolLanguageProvider(
             parsingService,
             javaGenerationService,
             migrationPlanService,
             indexingService,
             metricsService,
-            templateCodeGenerationService
+            templateCodeGenerationService,
+            db2MigrationService
         );
     }
 }

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CobolParsingService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CobolParsingService.java
@@ -16,6 +16,8 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.*;
 import java.util.stream.Stream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 import org.shark.renovatio.shared.domain.AnalyzeResult;
 import org.shark.renovatio.shared.domain.Workspace;
@@ -109,6 +111,34 @@ public class CobolParsingService {
                 .forEach(copybooks::add);
         }
         return copybooks;
+    }
+
+    /**
+     * Extract all embedded EXEC SQL statements from a COBOL source file.
+     * <p>
+     * This method performs a lightweight pattern scan rather than a full
+     * parse of the contained SQL. The returned list contains the raw SQL
+     * text between {@code EXEC SQL} and {@code END-EXEC} blocks.
+     */
+    public List<String> extractExecSqlStatements(Path cobolFile) throws IOException {
+        String content = Files.readString(cobolFile);
+        return extractExecSqlStatements(content);
+    }
+
+    /**
+     * Extract embedded EXEC SQL statements from COBOL source content.
+     */
+    public List<String> extractExecSqlStatements(String cobolSource) {
+        List<String> statements = new ArrayList<>();
+        Pattern pattern = Pattern.compile("EXEC\s+SQL(.*?)END-EXEC", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+        Matcher matcher = pattern.matcher(cobolSource);
+        while (matcher.find()) {
+            String sql = matcher.group(1).trim();
+            if (!sql.isEmpty()) {
+                statements.add(sql);
+            }
+        }
+        return statements;
     }
 
     /**

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/Db2MigrationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/Db2MigrationService.java
@@ -1,0 +1,121 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import freemarker.template.Configuration;
+import freemarker.template.Template;
+import freemarker.template.TemplateException;
+import org.springframework.stereotype.Service;
+
+import java.io.IOException;
+import java.io.StringReader;
+import java.io.StringWriter;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Service that migrates embedded DB2 EXEC SQL statements in COBOL programs
+ * into simple JPA entity and repository classes using template generation.
+ */
+@Service
+public class Db2MigrationService {
+
+    private final CobolParsingService parsingService;
+    private final Configuration freemarkerConfig;
+
+    public Db2MigrationService(CobolParsingService parsingService) {
+        this.parsingService = parsingService;
+        this.freemarkerConfig = new Configuration(Configuration.VERSION_2_3_32);
+        freemarkerConfig.setDefaultEncoding("UTF-8");
+    }
+
+    /**
+     * Generate JPA artifacts from EXEC SQL statements found in a COBOL file.
+     * The resulting map contains file names mapped to their Java source code.
+     */
+    public Map<String, String> migrateCobolFile(Path cobolFile) throws IOException, TemplateException {
+        List<String> statements = parsingService.extractExecSqlStatements(cobolFile);
+        Map<String, String> generated = new HashMap<>();
+        for (String sql : statements) {
+            String table = extractTableName(sql);
+            if (table == null) {
+                continue;
+            }
+            String entity = toPascalCase(table);
+            Map<String, Object> data = Map.of("entity", entity, "table", table);
+            generated.put(entity + ".java", generateEntity(data));
+            generated.put(entity + "Repository.java", generateRepository(data));
+        }
+        return generated;
+    }
+
+    private String extractTableName(String sql) {
+        Pattern p = Pattern.compile("from\\s+([a-zA-Z0-9_]+)", Pattern.CASE_INSENSITIVE);
+        Matcher m = p.matcher(sql);
+        if (m.find()) {
+            return m.group(1);
+        }
+        p = Pattern.compile("into\\s+([a-zA-Z0-9_]+)", Pattern.CASE_INSENSITIVE);
+        m = p.matcher(sql);
+        if (m.find()) {
+            return m.group(1);
+        }
+        return null;
+    }
+
+    private String generateEntity(Map<String, Object> data) throws IOException, TemplateException {
+        String templateContent = """
+        package org.shark.renovatio.generated.cobol;
+
+        import jakarta.persistence.Entity;
+        import jakarta.persistence.Id;
+
+        @Entity
+        public class ${entity} {
+            @Id
+            private Long id;
+            // TODO: map columns from ${table}
+        }
+        """;
+        Template template = new Template("entity", new StringReader(templateContent), freemarkerConfig);
+        StringWriter writer = new StringWriter();
+        template.process(data, writer);
+        return writer.toString();
+    }
+
+    private String generateRepository(Map<String, Object> data) throws IOException, TemplateException {
+        String templateContent = """
+        package org.shark.renovatio.generated.cobol;
+
+        import org.springframework.data.jpa.repository.JpaRepository;
+
+        public interface ${entity}Repository extends JpaRepository<${entity}, Long> {
+            // TODO: customise queries for ${table}
+        }
+        """;
+        Template template = new Template("repository", new StringReader(templateContent), freemarkerConfig);
+        StringWriter writer = new StringWriter();
+        template.process(data, writer);
+        return writer.toString();
+    }
+
+    private String toPascalCase(String text) {
+        if (text == null || text.isEmpty()) {
+            return "";
+        }
+        String[] parts = text.toLowerCase(Locale.ROOT).split("[^a-z0-9]");
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            if (part.isEmpty()) {
+                continue;
+            }
+            sb.append(Character.toUpperCase(part.charAt(0))).append(part.substring(1));
+        }
+        return sb.toString();
+    }
+}
+

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/CobolLanguageProviderTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/CobolLanguageProviderTest.java
@@ -29,6 +29,8 @@ class CobolLanguageProviderTest {
         // Initialize services
         CobolParsingService parsingService = new CobolParsingService();
         JavaGenerationService javaGenerationService = new JavaGenerationService(parsingService);
+        TemplateCodeGenerationService templateService = new TemplateCodeGenerationService();
+        Db2MigrationService db2Service = new Db2MigrationService(parsingService);
         MigrationPlanService migrationPlanService = new MigrationPlanService(parsingService, javaGenerationService);
         IndexingService indexingService = new IndexingService();
         MetricsService metricsService = new MetricsService();
@@ -38,7 +40,9 @@ class CobolLanguageProviderTest {
             javaGenerationService,
             migrationPlanService,
             indexingService,
-            metricsService
+            metricsService,
+            templateService,
+            db2Service
         );
 
         // Setup test workspace

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/Db2MigrationToolTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/Db2MigrationToolTest.java
@@ -10,16 +10,23 @@ import java.util.Map;
 
 import static org.junit.jupiter.api.Assertions.*;
 
-public class CopybookMigrationToolTest {
+/**
+ * Tests for DB2 migration MCP tool.
+ */
+public class Db2MigrationToolTest {
 
     @Test
-    void migrateCopybookGeneratesArtifacts() throws Exception {
-        Path temp = Files.createTempDirectory("cobol-copybook");
-        String copybook = "       01 CUSTOMER-REC.\n" +
-                "          05 CUSTOMER-ID PIC X(10).\n" +
-                "          05 CUSTOMER-AGE PIC 9(3).";
-        Path copybookFile = temp.resolve("CUSTOMER.cpy");
-        Files.writeString(copybookFile, copybook);
+    void migrateDb2GeneratesJpaArtifacts() throws Exception {
+        Path temp = Files.createTempDirectory("cobol-db2");
+        String cobol = "       IDENTIFICATION DIVISION.\n" +
+                "       PROGRAM-ID. SAMPLE.\n" +
+                "       PROCEDURE DIVISION.\n" +
+                "           EXEC SQL\n" +
+                "               SELECT * FROM CUSTOMER\n" +
+                "           END-EXEC.\n" +
+                "           STOP RUN.";
+        Path programFile = temp.resolve("SAMPLE.cob");
+        Files.writeString(programFile, cobol);
 
         CobolParsingService parsingService = new CobolParsingService();
         JavaGenerationService javaGenerationService = new JavaGenerationService(parsingService);
@@ -35,15 +42,16 @@ public class CopybookMigrationToolTest {
 
         Map<String, Object> args = Map.of(
                 "workspacePath", temp.toString(),
-                "copybook", "CUSTOMER.cpy"
+                "program", "SAMPLE.cob"
         );
 
-        Object result = tools.executeCobolTool("cobol.copybook.migrate", args);
+        Object result = tools.executeCobolTool("cobol.db2.migrate", args);
         assertTrue(result instanceof Map);
         Map<?,?> resMap = (Map<?,?>) result;
         assertEquals(true, resMap.get("success"));
         Map<?,?> files = (Map<?,?>) resMap.get("files");
-        assertTrue(files.containsKey("CustomerDTO.java"));
-        assertTrue(files.containsKey("CustomerService.java"));
+        assertTrue(files.containsKey("Customer.java"));
+        assertTrue(files.containsKey("CustomerRepository.java"));
     }
 }
+


### PR DESCRIPTION
## Summary
- parse EXEC SQL blocks from COBOL sources
- map DB2 SQL statements to JPA entity/repository templates
- expose `cobol.db2.migrate` MCP tool that returns generated Java code

## Testing
- `mvn -q -e -pl renovatio-provider-cobol test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bf15095188832e904050dc4b45de75