### PR TITLE
Detect CICS commands and scaffold REST endpoints

### DIFF
--- a/renovatio-provider-cobol/README.md
+++ b/renovatio-provider-cobol/README.md
@@ -11,6 +11,7 @@ The COBOL Provider is a comprehensive extension to Renovatio that adds capabilit
 - **AST extraction** for COBOL programs, data divisions, and procedure divisions
 - **Symbol detection** for data items, paragraphs, sections, and program structures
 - **Dependency analysis** across COBOL programs
+- **CICS command detection** for identifying transactional calls
 
 ### ☕ Java Code Generation
 - **JavaPoet integration** for type-safe Java code generation
@@ -54,6 +55,11 @@ The COBOL Provider is a comprehensive extension to Renovatio that adds capabilit
 - **Customizable templates** for different target frameworks
 - **Multi-file generation** with proper package structure
 - **Test code generation** for migration validation
+- **REST endpoint generation** for CICS transactions
+
+### 🔌 CICS Integration
+- **Configurable CICS service** with real or mock implementations via `renovatio.cics.*` properties
+- **Automatic endpoint scaffolding** for detected transactions
 
 ## Architecture
 

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
@@ -21,8 +21,10 @@ public class CobolProviderConfiguration {
     }
     
     @Bean
-    public JavaGenerationService javaGenerationService(CobolParsingService parsingService) {
-        return new JavaGenerationService(parsingService);
+    public JavaGenerationService javaGenerationService(
+            CobolParsingService parsingService,
+            TemplateCodeGenerationService templateCodeGenerationService) {
+        return new JavaGenerationService(parsingService, templateCodeGenerationService);
     }
     
     @Bean
@@ -40,6 +42,13 @@ public class CobolProviderConfiguration {
     @Bean
     public MetricsService metricsService() {
         return new MetricsService();
+    }
+
+    @Bean
+    public CicsService cicsService(
+            @Value("${renovatio.cics.mock:true}") boolean mock,
+            @Value("${renovatio.cics.url:http://localhost:10080}") String url) {
+        return mock ? new MockCicsService() : new RealCicsService(url);
     }
     
     @Bean

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CicsService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CicsService.java
@@ -1,0 +1,19 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import java.util.Map;
+
+/**
+ * Simple abstraction for invoking CICS transactions.
+ */
+public interface CicsService {
+
+    /**
+     * Invoke the given CICS transaction with the provided payload.
+     *
+     * @param transaction the CICS transaction or program name
+     * @param payload     input data
+     * @return raw response from the CICS layer
+     */
+    String invokeTransaction(String transaction, Map<String, Object> payload);
+}
+

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CobolParsingService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CobolParsingService.java
@@ -175,6 +175,7 @@ public class CobolParsingService {
         ast.put("calls", listener.getCalls());
         ast.put("copies", listener.getCopies());
         ast.put("dataItems", listener.getDataItems());
+        ast.put("cicsCommands", listener.getCicsCommands());
         ast.put("parseTree", tree.toStringTree(parser));
         ast.put("dialect", dialect.name());
         return ast;
@@ -208,6 +209,7 @@ public class CobolParsingService {
         private final Set<String> calls = new HashSet<>();
         private final Set<String> copies = new HashSet<>();
         private final List<Map<String, Object>> dataItems = new ArrayList<>();
+        private final Set<String> cicsCommands = new HashSet<>();
 
         @Override
         public void enterProgramIdParagraph(Cobol85Parser.ProgramIdParagraphContext ctx) {
@@ -233,6 +235,21 @@ public class CobolParsingService {
                 copies.add(ctx.textName().getText());
             }
         }
+
+        @Override
+        public void enterExecStatement(Cobol85Parser.ExecStatementContext ctx) {
+            String text = ctx.getText().toUpperCase(Locale.ROOT);
+            if (text.startsWith("EXECCICS")) {
+                String body = text.substring("EXECCICS".length());
+                if (body.endsWith("ENDEXEC")) {
+                    body = body.substring(0, body.length() - "ENDEXEC".length());
+                }
+                String[] parts = body.trim().split("\\s+");
+                if (parts.length > 0) {
+                    cicsCommands.add(parts[0]);
+                }
+            }
+        }
         
         @Override
         public void enterDataDescriptionEntryFormat1(Cobol85Parser.DataDescriptionEntryFormat1Context ctx) {
@@ -251,5 +268,6 @@ public class CobolParsingService {
         public Set<String> getCalls() { return calls; }
         public Set<String> getCopies() { return copies; }
         public List<Map<String, Object>> getDataItems() { return dataItems; }
+        public Set<String> getCicsCommands() { return cicsCommands; }
     }
 }

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/JavaGenerationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/JavaGenerationService.java
@@ -21,9 +21,11 @@ import java.util.*;
 public class JavaGenerationService {
     
     private final CobolParsingService parsingService;
-    
-    public JavaGenerationService(CobolParsingService parsingService) {
+    private final TemplateCodeGenerationService templateService;
+
+    public JavaGenerationService(CobolParsingService parsingService, TemplateCodeGenerationService templateService) {
         this.parsingService = parsingService;
+        this.templateService = templateService;
     }
     
     /**
@@ -60,6 +62,16 @@ public class JavaGenerationService {
                 // Generate implementation template
                 String serviceImpl = generateServiceImplementation(classBase, metadata);
                 generatedFiles.put(baseName + "ServiceImpl.java", serviceImpl);
+
+                @SuppressWarnings("unchecked")
+                Set<String> cics = (Set<String>) metadata.get("cicsCommands");
+                if (cics != null && !cics.isEmpty()) {
+                    Map<String, Object> tmplData = new HashMap<>();
+                    tmplData.put("className", classBase + "CicsController");
+                    tmplData.put("transactions", cics);
+                    String controller = templateService.generateCicsController(tmplData);
+                    generatedFiles.put(baseName + "CicsController.java", controller);
+                }
             }
 
             // Depuración: imprimir las claves generadas

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/MockCicsService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/MockCicsService.java
@@ -1,0 +1,15 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import java.util.Map;
+
+/**
+ * Mock implementation of {@link CicsService} that returns static responses.
+ */
+public class MockCicsService implements CicsService {
+
+    @Override
+    public String invokeTransaction(String transaction, Map<String, Object> payload) {
+        return "Mocked response for " + transaction;
+    }
+}
+

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/RealCicsService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/RealCicsService.java
@@ -1,0 +1,23 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import java.util.Map;
+
+/**
+ * Minimal placeholder implementation for connecting to a real CICS endpoint.
+ * In a production environment this would use a CICS client library.
+ */
+public class RealCicsService implements CicsService {
+
+    private final String url;
+
+    public RealCicsService(String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String invokeTransaction(String transaction, Map<String, Object> payload) {
+        // TODO: Implement real CICS connectivity
+        return "Invoked " + transaction + " at " + url;
+    }
+}
+

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java
@@ -220,6 +220,47 @@ public class TemplateCodeGenerationService {
         template.process(templateData, writer);
         return writer.toString();
     }
+
+    /**
+     * Generates a simple REST controller exposing CICS transactions as endpoints.
+     */
+    public String generateCicsController(Map<String, Object> templateData) throws IOException, TemplateException {
+        String templateContent = """
+        package org.shark.renovatio.generated.cobol;
+
+        import org.springframework.web.bind.annotation.*;
+        import org.springframework.http.ResponseEntity;
+        import java.util.Map;
+        import org.shark.renovatio.provider.cobol.service.CicsService;
+
+        /**
+         * Generated controller that forwards REST calls to CICS transactions.
+         */
+        @RestController
+        @RequestMapping("/api/cics")
+        public class ${className} {
+
+            private final CicsService cicsService;
+
+            public ${className}(CicsService cicsService) {
+                this.cicsService = cicsService;
+            }
+
+            <#list transactions as tx>
+            @PostMapping("/${tx?lower_case}")
+            public ResponseEntity<String> ${tx?lower_case}(@RequestBody Map<String, Object> payload) {
+                String result = cicsService.invokeTransaction("${tx}", payload);
+                return ResponseEntity.ok(result);
+            }
+            </#list>
+        }
+        """;
+
+        Template template = new Template("cicsController", new StringReader(templateContent), freemarkerConfig);
+        StringWriter writer = new StringWriter();
+        template.process(templateData, writer);
+        return writer.toString();
+    }
     
     /**
      * Generates MapStruct mapper interface

--- a/renovatio-provider-cobol/src/main/resources/application-cobol.yml
+++ b/renovatio-provider-cobol/src/main/resources/application-cobol.yml
@@ -76,6 +76,12 @@ renovatio:
       default-strategy: incremental
       backup-original: true
       validation-enabled: true
+
+    cics:
+      # Use a mock CICS service by default
+      mock: true
+      # Base URL for real CICS services
+      url: http://localhost:10080
       
     # Indexing configuration
     indexing:

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/CobolParsingServiceCicsTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/CobolParsingServiceCicsTest.java
@@ -1,0 +1,38 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+/**
+ * Verifies that CICS commands are detected during COBOL analysis.
+ */
+class CobolParsingServiceCicsTest {
+
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void detectsCicsCommands() throws Exception {
+        CobolParsingService service = new CobolParsingService();
+        Path cob = tempDir.resolve("sample.cob");
+        String source = String.join("\n",
+                "IDENTIFICATION DIVISION.",
+                "PROGRAM-ID. TEST.",
+                "PROCEDURE DIVISION.",
+                "    EXEC CICS SEND TEXT('HI') END-EXEC.",
+                "    STOP RUN.");
+        Files.writeString(cob, source);
+
+        Map<String, Object> result = service.parseCobolFile(cob);
+        @SuppressWarnings("unchecked")
+        var cmds = (java.util.Set<String>) result.get("cicsCommands");
+        assertTrue(cmds.contains("SEND"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- detect EXEC CICS statements during COBOL parsing and expose commands
- generate REST controllers for detected CICS transactions via templates
- add configurable CICS service allowing mock or real backend

## Testing
- `mvn -q -pl renovatio-provider-cobol -am test` *(fails: Non-resolvable parent POM due to network)*

------
https://chatgpt.com/codex/tasks/task_e_68bf12c69644832eacdcfb33468f9203