### PR TITLE
Add JCL provider and MCP translation tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -406,6 +406,9 @@ renovatio/
 │   └── infrastructure/               # Configuración e integración MCP
 │       ├── CobolProviderConfiguration.java # Configuración Spring
 │       └── CobolMcpToolsProvider.java # Proveedor de herramientas MCP
+├── renovatio-provider-jcl/            # Proveedor JCL (traducción a shell/CI)
+│   ├── service/                      # Parser y traductor JCL
+│   └── infrastructure/               # Herramientas MCP para conversión
 ├── renovatio-agent/                   # Agente de ejecución
 ├── renovatio-web/                     # Aplicación web principal
 │   ├── McpServerApplication.java      # Aplicación principal Spring Boot
@@ -550,6 +553,11 @@ mvn clean compile
 mvn clean compile -pl renovatio-provider-cobol
 ```
 
+### Compilar Solo el Proveedor JCL
+```bash
+mvn clean compile -pl renovatio-provider-jcl
+```
+
 ### Ejecutar Tests
 ```bash
 # Todos los tests
@@ -560,6 +568,9 @@ mvn test -pl renovatio-provider-cobol
 
 # Solo tests de Java/OpenRewrite
 mvn test -pl renovatio-provider-java
+
+# Solo tests de JCL
+mvn test -pl renovatio-provider-jcl
 ```
 
 ### Ejecutar con Perfil COBOL Habilitado

--- a/pom.xml
+++ b/pom.xml
@@ -36,15 +36,16 @@
         <micrometer.version>1.12.1</micrometer.version>
     </properties>
     
-    <modules>
-        <module>renovatio-shared</module>
-        <module>renovatio-core</module>
-        <module>renovatio-provider-java</module>
-        <module>renovatio-provider-cobol</module>
-        <module>renovatio-agent</module>
-        <module>renovatio-web</module>
-        <module>renovatio-client</module>
-    </modules>
+      <modules>
+          <module>renovatio-shared</module>
+          <module>renovatio-core</module>
+          <module>renovatio-provider-java</module>
+          <module>renovatio-provider-cobol</module>
+          <module>renovatio-provider-jcl</module>
+          <module>renovatio-agent</module>
+          <module>renovatio-web</module>
+          <module>renovatio-client</module>
+      </modules>
     
     <dependencyManagement>
         <dependencies>
@@ -64,11 +65,16 @@
                 <artifactId>renovatio-provider-java</artifactId>
                 <version>${project.version}</version>
             </dependency>
-            <dependency>
-                <groupId>org.shark.renovatio</groupId>
-                <artifactId>renovatio-provider-cobol</artifactId>
-                <version>${project.version}</version>
-            </dependency>
+              <dependency>
+                  <groupId>org.shark.renovatio</groupId>
+                  <artifactId>renovatio-provider-cobol</artifactId>
+                  <version>${project.version}</version>
+              </dependency>
+              <dependency>
+                  <groupId>org.shark.renovatio</groupId>
+                  <artifactId>renovatio-provider-jcl</artifactId>
+                  <version>${project.version}</version>
+              </dependency>
             
             <!-- External dependencies -->
             <dependency>

--- a/renovatio-agent/pom.xml
+++ b/renovatio-agent/pom.xml
@@ -33,6 +33,10 @@
             <artifactId>renovatio-provider-cobol</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>renovatio-provider-jcl</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>

--- a/renovatio-provider-jcl/pom.xml
+++ b/renovatio-provider-jcl/pom.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.shark.renovatio</groupId>
+        <artifactId>renovatio-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>renovatio-provider-jcl</artifactId>
+    <name>Renovatio JCL Provider</name>
+    <description>JCL script parsing and translation utilities</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>renovatio-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework</groupId>
+            <artifactId>spring-context</artifactId>
+        </dependency>
+    </dependencies>
+</project>

--- a/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/domain/JclMcpTool.java
+++ b/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/domain/JclMcpTool.java
@@ -1,0 +1,44 @@
+package org.shark.renovatio.provider.jcl.domain;
+
+import java.util.Map;
+
+/**
+ * Simple MCP Tool representation for the JCL provider.
+ */
+public class JclMcpTool {
+    private String name;
+    private String description;
+    private Map<String, Object> inputSchema;
+
+    public JclMcpTool() {
+    }
+
+    public JclMcpTool(String name, String description) {
+        this.name = name;
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    public Map<String, Object> getInputSchema() {
+        return inputSchema;
+    }
+
+    public void setInputSchema(Map<String, Object> inputSchema) {
+        this.inputSchema = inputSchema;
+    }
+}

--- a/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/domain/JclStep.java
+++ b/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/domain/JclStep.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.provider.jcl.domain;
+
+/**
+ * Representation of a single JCL execution step.
+ */
+public class JclStep {
+    private final String name;
+    private final String program;
+
+    public JclStep(String name, String program) {
+        this.name = name;
+        this.program = program;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getProgram() {
+        return program;
+    }
+}

--- a/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/infrastructure/JclMcpToolsProvider.java
+++ b/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/infrastructure/JclMcpToolsProvider.java
@@ -1,0 +1,68 @@
+package org.shark.renovatio.provider.jcl.infrastructure;
+
+import org.shark.renovatio.provider.jcl.domain.JclMcpTool;
+import org.shark.renovatio.provider.jcl.service.JclTranslationService;
+import org.springframework.stereotype.Component;
+
+import java.util.*;
+
+/**
+ * Exposes JCL conversion utilities as MCP tools.
+ */
+@Component
+public class JclMcpToolsProvider {
+
+    private final JclTranslationService translationService;
+
+    public JclMcpToolsProvider(JclTranslationService translationService) {
+        this.translationService = translationService;
+    }
+
+    /**
+     * List available JCL tools.
+     */
+    public List<JclMcpTool> getJclTools() {
+        return List.of(createConvertTool());
+    }
+
+    /**
+     * Execute the given JCL tool.
+     */
+    public Object executeJclTool(String toolName, Map<String, Object> arguments) {
+        if ("jcl.convert".equals(toolName)) {
+            return executeConvert(arguments);
+        }
+        return Map.of("error", "Unknown JCL tool: " + toolName);
+    }
+
+    private JclMcpTool createConvertTool() {
+        JclMcpTool tool = new JclMcpTool();
+        tool.setName("jcl.convert");
+        tool.setDescription("Convert JCL steps to shell scripts or CI workflows");
+
+        Map<String, Object> schema = new HashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", Map.of(
+                "jcl", Map.of("type", "string", "description", "JCL content"),
+                "target", Map.of("type", "string", "description", "shell or github-actions")
+        ));
+        schema.put("required", List.of("jcl", "target"));
+        tool.setInputSchema(schema);
+        return tool;
+    }
+
+    private Object executeConvert(Map<String, Object> arguments) {
+        String jcl = (String) arguments.get("jcl");
+        String target = (String) arguments.getOrDefault("target", "shell");
+        String script;
+        if ("github-actions".equalsIgnoreCase(target) || "ci".equalsIgnoreCase(target)) {
+            script = translationService.toGithubActions(jcl);
+        } else {
+            script = translationService.toShellScript(jcl);
+        }
+        return Map.of(
+                "success", true,
+                "script", script
+        );
+    }
+}

--- a/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/service/JclTranslationService.java
+++ b/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/service/JclTranslationService.java
@@ -1,0 +1,71 @@
+package org.shark.renovatio.provider.jcl.service;
+
+import org.shark.renovatio.provider.jcl.domain.JclStep;
+import org.springframework.stereotype.Service;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Basic parser and translator for JCL scripts.
+ * Extracts EXEC steps and can convert them into shell scripts or
+ * simple CI workflow steps (GitHub Actions style).
+ */
+@Service
+public class JclTranslationService {
+    private static final Pattern STEP_PATTERN =
+            Pattern.compile("^//([^\s]+)\\s+EXEC\\s+PGM=([^\\s,]+)", Pattern.CASE_INSENSITIVE);
+
+    /**
+     * Parse the provided JCL content and extract executable steps.
+     */
+    public List<JclStep> parseSteps(String jclContent) {
+        List<JclStep> steps = new ArrayList<>();
+        if (jclContent == null) {
+            return steps;
+        }
+        for (String line : jclContent.split("\\R")) {
+            Matcher m = STEP_PATTERN.matcher(line.trim());
+            if (m.find()) {
+                String name = m.group(1);
+                String program = m.group(2);
+                steps.add(new JclStep(name, program));
+            }
+        }
+        return steps;
+    }
+
+    /**
+     * Convert JCL steps into a simple shell script.
+     */
+    public String toShellScript(String jclContent) {
+        List<JclStep> steps = parseSteps(jclContent);
+        StringBuilder sb = new StringBuilder();
+        sb.append("#!/bin/sh\n");
+        sb.append("# Generated from JCL\n");
+        for (JclStep step : steps) {
+            sb.append("# ").append(step.getName()).append('\n');
+            sb.append(step.getProgram()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Convert JCL steps into a minimal GitHub Actions workflow.
+     */
+    public String toGithubActions(String jclContent) {
+        List<JclStep> steps = parseSteps(jclContent);
+        StringBuilder sb = new StringBuilder();
+        sb.append("jobs:\n");
+        sb.append("  jcl:\n");
+        sb.append("    runs-on: ubuntu-latest\n");
+        sb.append("    steps:\n");
+        for (JclStep step : steps) {
+            sb.append("      - name: ").append(step.getName()).append("\n");
+            sb.append("        run: ").append(step.getProgram()).append("\n");
+        }
+        return sb.toString();
+    }
+}


### PR DESCRIPTION
## Summary
- add new `renovatio-provider-jcl` module for parsing JCL steps
- translate JCL to shell scripts or GitHub Actions workflow
- expose conversion through `jcl.convert` MCP tool and wire into build

## Testing
- `mvn -q -pl renovatio-provider-jcl test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68bef2cd3954832eaba990188dc67630