### PR TITLE
Add COBOL parser dialect profiles

### DIFF
--- a/renovatio-provider-cobol/AST_EXAMPLES.md
+++ b/renovatio-provider-cobol/AST_EXAMPLES.md
@@ -1,0 +1,38 @@
+# Ejemplos de AST COBOL
+
+Estos fragmentos muestran cómo los parsers generan un árbol de sintaxis abstracta (AST) a partir de un programa sencillo.
+
+## Programa de ejemplo
+
+```cobol
+       IDENTIFICATION DIVISION.
+       PROGRAM-ID. HELLO.
+       PROCEDURE DIVISION.
+           DISPLAY "HELLO".
+           STOP RUN.
+```
+
+## AST con ProLeap
+
+```text
+Program
+└─CompilationUnit
+  └─ProgramUnit (HELLO)
+    ├─IdentificationDivision
+    └─ProcedureDivision
+      ├─DisplayStatement("HELLO")
+      └─StopStatement
+```
+
+## AST con Koopa
+
+```text
+compilation-unit
+└─program-unit name=HELLO
+  └─procedure-division
+    ├─display-statement value="HELLO"
+    └─stop-statement
+```
+
+Estos árboles pueden utilizarse como referencia para validar el parsing en pruebas automáticas o análisis manuales.
+

--- a/renovatio-provider-cobol/README.md
+++ b/renovatio-provider-cobol/README.md
@@ -7,7 +7,7 @@ The COBOL Provider is a comprehensive extension to Renovatio that adds capabilit
 ## Features
 
 ### 🔍 COBOL Analysis & Parsing
-- **Pattern-based COBOL parsing** with extensible architecture for future ProLeap/Koopa integration
+- **Pluggable parsers** with ProLeap (default) and Koopa dialects seleccionables via perfiles de build
 - **AST extraction** for COBOL programs, data divisions, and procedure divisions
 - **Symbol detection** for data items, paragraphs, sections, and program structures
 - **Dependency analysis** across COBOL programs
@@ -60,6 +60,31 @@ The COBOL Provider is a comprehensive extension to Renovatio that adds capabilit
 ### 🔌 CICS Integration
 - **Configurable CICS service** with real or mock implementations via `renovatio.cics.*` properties
 - **Automatic endpoint scaffolding** for detected transactions
+
+## Dialect Profiles
+
+Different COBOL dialects can be selected at build time.
+
+### Maven
+
+- ProLeap (predeterminado):
+  ```bash
+  mvn -pl renovatio-provider-cobol -Pproleap test
+  ```
+- Koopa:
+  ```bash
+  mvn -pl renovatio-provider-cobol -Pkoopa test
+  ```
+
+### Gradle
+
+Usando la propiedad `dialect`:
+```bash
+gradle :renovatio-provider-cobol:test             # ProLeap
+gradle :renovatio-provider-cobol:test -Pdialect=koopa
+```
+
+Para ejemplos de árboles de sintaxis generados consulta [AST_EXAMPLES.md](AST_EXAMPLES.md).
 
 ## Architecture
 

--- a/renovatio-provider-cobol/build.gradle
+++ b/renovatio-provider-cobol/build.gradle
@@ -1,0 +1,33 @@
+plugins {
+    id 'java'
+}
+
+ext.dialect = project.findProperty('dialect') ?: 'proleap'
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation project(':renovatio-shared')
+    implementation 'org.springframework:spring-context'
+    implementation 'com.squareup:javapoet'
+    implementation 'org.freemarker:freemarker'
+    implementation 'org.mapstruct:mapstruct'
+    annotationProcessor 'org.mapstruct:mapstruct-processor'
+    implementation 'org.apache.lucene:lucene-core'
+    implementation 'org.apache.lucene:lucene-queryparser'
+    implementation 'org.apache.lucene:lucene-analysis-common'
+    implementation 'org.eclipse.jgit:org.eclipse.jgit'
+    implementation 'dev.langchain4j:langchain4j'
+    implementation 'org.antlr:antlr4-runtime'
+    implementation 'io.github.resilience4j:resilience4j-spring-boot3'
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+
+    if (dialect == 'koopa') {
+        implementation 'net.sf.koopa:koopa:1.0.0'
+    } else {
+        implementation 'io.proleap:proleap-cobol-parser:2.3.0'
+    }
+}
+

--- a/renovatio-provider-cobol/pom.xml
+++ b/renovatio-provider-cobol/pom.xml
@@ -78,13 +78,6 @@
             <groupId>org.antlr</groupId>
             <artifactId>antlr4-runtime</artifactId>
         </dependency>
-
-        <!-- ProLeap COBOL parser for AST generation -->
-        <dependency>
-            <groupId>io.proleap</groupId>
-            <artifactId>proleap-cobol-parser</artifactId>
-            <version>2.3.0</version>
-        </dependency>
         
         <!-- Resilience -->
         <dependency>
@@ -99,4 +92,39 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
+    <profiles>
+        <!-- Default parsing using ProLeap -->
+        <profile>
+            <id>proleap</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <properties>
+                <cobol.dialect>proleap</cobol.dialect>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>io.proleap</groupId>
+                    <artifactId>proleap-cobol-parser</artifactId>
+                    <version>2.3.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+
+        <!-- Alternative parsing using Koopa -->
+        <profile>
+            <id>koopa</id>
+            <properties>
+                <cobol.dialect>koopa</cobol.dialect>
+            </properties>
+            <dependencies>
+                <dependency>
+                    <groupId>net.sf.koopa</groupId>
+                    <artifactId>koopa</artifactId>
+                    <version>1.0.0</version>
+                </dependency>
+            </dependencies>
+        </profile>
+    </profiles>
 </project>


### PR DESCRIPTION
## Summary
- allow switching between ProLeap and Koopa parsers in the COBOL provider
- add Gradle support for selecting parser dialect via project property
- document sample COBOL ASTs for parsing verification

## Testing
- `mvn -q -pl renovatio-provider-cobol test` *(fails: Non-resolvable parent POM; Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c010706e4c832eaf9bad0f397af580