### PR TITLE
Add dataset adapters and export templates

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -34,6 +34,9 @@
         <antlr4.version>4.13.1</antlr4.version>
         <resilience4j.version>2.1.0</resilience4j.version>
         <micrometer.version>1.12.1</micrometer.version>
+        <cb2xml.version>1.0.1</cb2xml.version>
+        <jrecord.version>0.98.65</jrecord.version>
+        <mustache.version>0.9.10</mustache.version>
     </properties>
     
       <modules>
@@ -128,6 +131,24 @@
                 <groupId>org.freemarker</groupId>
                 <artifactId>freemarker</artifactId>
                 <version>${freemarker.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.sf.cb2xml</groupId>
+                <artifactId>cb2xml</artifactId>
+                <version>${cb2xml.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>net.sf.jrecord</groupId>
+                <artifactId>jrecord</artifactId>
+                <version>${jrecord.version}</version>
+            </dependency>
+
+            <dependency>
+                <groupId>com.github.spullara.mustache.java</groupId>
+                <artifactId>compiler</artifactId>
+                <version>${mustache.version}</version>
             </dependency>
             
             <!-- Object mapping -->

--- a/renovatio-provider-cobol/pom.xml
+++ b/renovatio-provider-cobol/pom.xml
@@ -35,6 +35,22 @@
             <groupId>org.freemarker</groupId>
             <artifactId>freemarker</artifactId>
         </dependency>
+
+        <!-- Copybook parsing and model generation -->
+        <dependency>
+            <groupId>net.sf.cb2xml</groupId>
+            <artifactId>cb2xml</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>net.sf.jrecord</groupId>
+            <artifactId>jrecord</artifactId>
+        </dependency>
+
+        <!-- Additional templating engine -->
+        <dependency>
+            <groupId>com.github.spullara.mustache.java</groupId>
+            <artifactId>compiler</artifactId>
+        </dependency>
         
         <!-- Object mapping -->
         <dependency>

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/domain/DatasetAdapter.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/domain/DatasetAdapter.java
@@ -1,0 +1,20 @@
+package org.shark.renovatio.provider.cobol.domain;
+
+import java.util.Map;
+
+/**
+ * Generic adapter that transforms dataset representations into
+ * persistable structures such as {@link java.util.Map}.
+ *
+ * @param <T> source dataset type
+ */
+public interface DatasetAdapter<T> {
+
+    /**
+     * Transform the provided dataset into a persistable map of field names to values.
+     *
+     * @param dataset source dataset instance
+     * @return map representation suitable for persistence
+     */
+    Map<String, Object> toPersistable(T dataset);
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/domain/JRecordDatasetAdapter.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/domain/JRecordDatasetAdapter.java
@@ -1,0 +1,32 @@
+package org.shark.renovatio.provider.cobol.domain;
+
+import net.sf.JRecord.Details.AbstractLine;
+import net.sf.JRecord.Details.LayoutDetail;
+import net.sf.JRecord.Details.RecordDetail;
+import net.sf.JRecord.Details.FieldDetail;
+
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ * Adapter implementation that converts jRecord {@link AbstractLine} datasets
+ * into simple {@link Map} structures that can later be persisted in a
+ * database or object store.
+ */
+public class JRecordDatasetAdapter implements DatasetAdapter<AbstractLine> {
+
+    @Override
+    public Map<String, Object> toPersistable(AbstractLine line) {
+        Map<String, Object> record = new LinkedHashMap<>();
+        if (line == null) {
+            return record;
+        }
+        LayoutDetail layout = line.getLayout();
+        RecordDetail recordDetail = layout.getRecord(0);
+        for (int i = 0; i < recordDetail.getFieldCount(); i++) {
+            FieldDetail field = recordDetail.getField(i);
+            record.put(field.getName(), line.getFieldValue(field).asString());
+        }
+        return record;
+    }
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CopybookModelGenerator.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CopybookModelGenerator.java
@@ -1,0 +1,60 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import net.sf.cb2xml.Cb2Xml;
+import net.sf.JRecord.External.CopybookLoader;
+import net.sf.JRecord.External.CopybookLoaderFactory;
+import net.sf.JRecord.External.ExternalRecord;
+import net.sf.JRecord.Details.LayoutDetail;
+import net.sf.JRecord.Details.FieldDetail;
+import net.sf.JRecord.Numeric.ICopybookDialects;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+
+/**
+ * Service that evaluates CB2XML and jRecord for generating simple
+ * Java model representations from COBOL copybooks.
+ */
+public class CopybookModelGenerator {
+
+    /**
+     * Converts a COBOL copybook into its XML representation using CB2XML.
+     *
+     * @param copybookPath path to the copybook file
+     * @return XML representation of the copybook
+     */
+    public String copybookToXml(Path copybookPath) throws IOException {
+        try (InputStream is = Files.newInputStream(copybookPath)) {
+            return Cb2Xml.convertToXMLString(is);
+        }
+    }
+
+    /**
+     * Loads a copybook as a jRecord {@link ExternalRecord}.
+     */
+    public ExternalRecord loadExternalRecord(Path copybookPath) throws IOException {
+        return CopybookLoaderFactory.getInstance()
+                .getLoader(CopybookLoaderFactory.COBOL_LOADER)
+                .loadCopyBook(copybookPath.toString(), CopybookLoader.SPLIT_01_LEVEL,
+                        0, "", ICopybookDialects.FMT_MAINFRAME, 0, 0, null);
+    }
+
+    /**
+     * Generates a very simple Java POJO with String fields for every copybook field.
+     * This demonstrates the capability of jRecord to provide structural information
+     * that can drive Java model generation.
+     */
+    public String generateJavaModel(Path copybookPath, String className) throws IOException {
+        ExternalRecord record = loadExternalRecord(copybookPath);
+        LayoutDetail layout = record.asLayoutDetail();
+        StringBuilder sb = new StringBuilder("public class ").append(className).append(" {\n");
+        for (int i = 0; i < layout.getFieldCount(); i++) {
+            FieldDetail field = layout.getField(i);
+            sb.append("    private String ").append(field.getName()).append(";\n");
+        }
+        sb.append("}\n");
+        return sb.toString();
+    }
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java
@@ -13,6 +13,8 @@ import java.util.Map;
 import java.util.List;
 import java.util.ArrayList;
 import java.util.Locale;
+import com.github.mustachejava.DefaultMustacheFactory;
+import com.github.mustachejava.Mustache;
 
 /**
  * Template-based code generation service using Freemarker
@@ -300,6 +302,48 @@ public class TemplateCodeGenerationService {
         Template template = new Template("mapper", new StringReader(templateContent), freemarkerConfig);
         StringWriter writer = new StringWriter();
         template.process(templateData, writer);
+        return writer.toString();
+    }
+
+    /**
+     * Generates a simple exporter class that produces SQL insert statements for RDBMS targets.
+     */
+    public String generateRdbmsExporter(Map<String, Object> templateData) throws IOException, TemplateException {
+        String templateContent = """
+        package org.shark.renovatio.generated.cobol;
+
+        /**
+         * Utility class for exporting DTOs to a relational database.
+         */
+        public class ${className}RdbmsExporter {
+
+            public String toInsertSql(${className} dto) {
+                // Simplified example - build INSERT statement from DTO
+                return "INSERT INTO ${tableName} (...) VALUES (...);";
+            }
+        }
+        """;
+
+        Template template = new Template("rdbmsExporter", new StringReader(templateContent), freemarkerConfig);
+        StringWriter writer = new StringWriter();
+        template.process(templateData, writer);
+        return writer.toString();
+    }
+
+    /**
+     * Generates a basic exporter class that uploads DTO representations to S3 using Mustache templates.
+     */
+    public String generateS3Exporter(Map<String, Object> templateData) throws IOException {
+        String templateContent = "package org.shark.renovatio.generated.cobol;\n\n" +
+                "public class {{className}}S3Exporter {\n" +
+                "    public void export({{className}} dto) {\n" +
+                "        // TODO: stream DTO to S3 bucket {{bucketName}}\n" +
+                "    }\n" +
+                "}\n";
+        DefaultMustacheFactory mf = new DefaultMustacheFactory();
+        Mustache mustache = mf.compile(new StringReader(templateContent), "s3Exporter");
+        StringWriter writer = new StringWriter();
+        mustache.execute(writer, templateData).flush();
         return writer.toString();
     }
 


### PR DESCRIPTION
## Summary
- add cb2xml/jRecord/mustache dependencies
- introduce dataset adapter interfaces and jRecord implementation
- generate RDBMS and S3 export templates and copybook model generator

## Testing
- `mvn -q -pl renovatio-provider-cobol -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c011c4b82c832e810645fe05e57cb1