### PR TITLE
feat: parse JCL to AST and generate batch jobs

### DIFF
--- a/docs/jcl-job-deployment.md
+++ b/docs/jcl-job-deployment.md
@@ -1,0 +1,21 @@
+# Despliegue de Jobs Generados desde JCL
+
+Los jobs convertidos desde JCL pueden ejecutarse en distintos frameworks de orquestación. A continuación se describen opciones para desplegarlos en **Spring Batch**, **Airflow** y ejecutarlos en **Kubernetes** u otros schedulers.
+
+## Spring Batch en Kubernetes
+1. Construir una imagen de contenedor que incluya la aplicación Spring Boot con el job Spring Batch generado.
+2. Definir un `ConfigMap` o `Secret` con el XML del job si se requiere externalizarlo.
+3. Crear un `Job` de Kubernetes que invoque la clase `CommandLineJobRunner` o un `CronJob` para ejecuciones periódicas.
+4. Monitorear la ejecución mediante los logs del `Pod` o integrando herramientas como Prometheus y Grafana.
+
+## Airflow
+1. Colocar el DAG generado en el directorio de DAGs de Airflow.
+2. Si se usa Airflow en Kubernetes (mediante Helm o el operador oficial), empaquetar el DAG como parte de la imagen o montarlo como volumen.
+3. Configurar las dependencias necesarias en la imagen de Airflow para que los comandos del DAG se ejecuten correctamente.
+4. Programar el DAG desde la UI de Airflow o mediante una definición de `schedule_interval` en el archivo Python.
+
+## Otros Schedulers
+- **Cron tradicional**: Guardar el script generado y registrarlo con `crontab` en un servidor Unix/Linux.
+- **Herramientas de CI/CD**: Integrar el workflow generado en sistemas como Jenkins, GitHub Actions o GitLab CI.
+
+Estas estrategias permiten ejecutar los jobs resultantes de la migración JCL en plataformas modernas, facilitando la adopción de contenedores y orquestadores contemporáneos.

--- a/renovatio-provider-jcl/pom.xml
+++ b/renovatio-provider-jcl/pom.xml
@@ -23,5 +23,11 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.zowe</groupId>
+            <artifactId>jcl4j</artifactId>
+            <version>1.0.0</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/service/JclTranslationService.java
+++ b/renovatio-provider-jcl/src/main/java/org/shark/renovatio/provider/jcl/service/JclTranslationService.java
@@ -3,6 +3,7 @@ package org.shark.renovatio.provider.jcl.service;
 import org.shark.renovatio.provider.jcl.domain.JclStep;
 import org.springframework.stereotype.Service;
 
+import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.regex.Matcher;
@@ -21,8 +22,40 @@ public class JclTranslationService {
     /**
      * Parse the provided JCL content and extract executable steps.
      */
+    public Object parseAst(String jclContent) {
+        try {
+            Class<?> parserClass = Class.forName("org.zowe.jclparser.JclParser");
+            Object parser = parserClass.getDeclaredConstructor().newInstance();
+            Method parse = parserClass.getMethod("parse", String.class);
+            return parse.invoke(parser, jclContent);
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    /**
+     * Parse the provided JCL content and extract executable steps.
+     * Uses jcl4j when available, otherwise falls back to a regex parser.
+     */
     public List<JclStep> parseSteps(String jclContent) {
         List<JclStep> steps = new ArrayList<>();
+        Object ast = parseAst(jclContent);
+        if (ast != null) {
+            try {
+                Method getSteps = ast.getClass().getMethod("getSteps");
+                List<?> parsedSteps = (List<?>) getSteps.invoke(ast);
+                for (Object s : parsedSteps) {
+                    Method getName = s.getClass().getMethod("getName");
+                    Method getProgram = s.getClass().getMethod("getProgram");
+                    String name = (String) getName.invoke(s);
+                    String program = (String) getProgram.invoke(s);
+                    steps.add(new JclStep(name, program));
+                }
+                return steps;
+            } catch (Exception ignored) {
+                // fall back to regex parsing
+            }
+        }
         if (jclContent == null) {
             return steps;
         }
@@ -65,6 +98,59 @@ public class JclTranslationService {
         for (JclStep step : steps) {
             sb.append("      - name: ").append(step.getName()).append("\n");
             sb.append("        run: ").append(step.getProgram()).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Convert JCL steps into a simple Spring Batch XML job definition.
+     */
+    public String toSpringBatchJob(String jclContent) {
+        List<JclStep> steps = parseSteps(jclContent);
+        StringBuilder sb = new StringBuilder();
+        sb.append("<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n");
+        sb.append("<beans xmlns=\"http://www.springframework.org/schema/beans\"\n");
+        sb.append("       xmlns:batch=\"http://www.springframework.org/schema/batch\"\n");
+        sb.append("       xmlns:xsi=\"http://www.w3.org/2001/XMLSchema-instance\"\n");
+        sb.append("       xsi:schemaLocation=\"http://www.springframework.org/schema/beans https://www.springframework.org/schema/beans/spring-beans.xsd\n");
+        sb.append("                           http://www.springframework.org/schema/batch https://www.springframework.org/schema/batch/spring-batch.xsd\">\n");
+        sb.append("  <batch:job id=\"jclJob\">\n");
+        for (JclStep step : steps) {
+            sb.append("    <batch:step id=\"").append(step.getName()).append("\">\n");
+            sb.append("      <batch:tasklet>\n");
+            sb.append("        <batch:script>").append(step.getProgram()).append("</batch:script>\n");
+            sb.append("      </batch:tasklet>\n");
+            sb.append("    </batch:step>\n");
+        }
+        sb.append("  </batch:job>\n");
+        sb.append("</beans>\n");
+        return sb.toString();
+    }
+
+    /**
+     * Convert JCL steps into a minimal Airflow DAG using BashOperator tasks.
+     */
+    public String toAirflowDag(String jclContent) {
+        List<JclStep> steps = parseSteps(jclContent);
+        StringBuilder sb = new StringBuilder();
+        sb.append("from airflow import DAG\n");
+        sb.append("from airflow.operators.bash import BashOperator\n");
+        sb.append("from datetime import datetime\n\n");
+        sb.append("with DAG('jcl_job', start_date=datetime(2024, 1, 1), schedule_interval=None) as dag:\n");
+        JclStep previous = null;
+        for (JclStep step : steps) {
+            String taskId = step.getName().toLowerCase();
+            sb.append("    ").append(taskId).append(" = BashOperator(task_id='")
+              .append(taskId).append("', bash_command='")
+              .append(step.getProgram()).append("')\n");
+            if (previous != null) {
+                sb.append("    ")
+                  .append(previous.getName().toLowerCase())
+                  .append(" >> ")
+                  .append(taskId)
+                  .append("\n");
+            }
+            previous = step;
         }
         return sb.toString();
     }


### PR DESCRIPTION
## Summary
- add optional jcl4j dependency
- parse JCL via jcl4j AST with Spring Batch and Airflow translations
- document deployment of generated jobs on Kubernetes and other schedulers

## Testing
- `mvn -q -pl renovatio-provider-jcl test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c01405717c832e8d0fff11d74c2c4c