### PR TITLE
feat: integrate Zowe CICS client

### DIFF
--- a/renovatio-provider-cobol/README.md
+++ b/renovatio-provider-cobol/README.md
@@ -61,6 +61,25 @@ The COBOL Provider is a comprehensive extension to Renovatio that adds capabilit
 - **Configurable CICS service** with real or mock implementations via `renovatio.cics.*` properties
 - **Automatic endpoint scaffolding** for detected transactions
 
+#### Manual invocation example
+
+Once a controller has been generated and the CICS service is configured for
+real connectivity (`renovatio.cics.mock=false`), transactions can be tested
+manually.  The generated endpoints follow the pattern
+`POST /api/cics/<transaction>` using lower-case transaction names.
+
+Example:
+
+```bash
+curl -X POST \
+  -H "Content-Type: application/json" \
+  -d '{"account":"12345"}' \
+  http://localhost:8080/api/cics/tran1
+```
+
+The request above is routed through `RealCicsService`, which maps the
+`TRAN1` transaction to the corresponding Zowe CICS/JCICS REST endpoint.
+
 ## Dialect Profiles
 
 Different COBOL dialects can be selected at build time.

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
@@ -49,6 +49,9 @@ public class CobolProviderConfiguration {
             @Value("${renovatio.cics.mock:true}") boolean mock,
             @Value("${renovatio.cics.url:http://localhost:10080}") String url) {
         return mock ? new MockCicsService() : new RealCicsService(url);
+    }
+
+    @Bean
     public Db2MigrationService db2MigrationService(CobolParsingService parsingService) {
         return new Db2MigrationService(parsingService);
     }

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/RealCicsService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/RealCicsService.java
@@ -1,23 +1,39 @@
 package org.shark.renovatio.provider.cobol.service;
 
+import java.util.HashMap;
 import java.util.Map;
 
 /**
- * Minimal placeholder implementation for connecting to a real CICS endpoint.
- * In a production environment this would use a CICS client library.
+ * Implementation of {@link CicsService} that delegates calls to a
+ * Zowe CICS/JCICS REST endpoint. Transactions are mapped to concrete
+ * REST paths which are invoked using {@link ZoweCicsClient}.
  */
 public class RealCicsService implements CicsService {
 
-    private final String url;
+    private final String baseUrl;
+    private final Map<String, String> transactionEndpoints = new HashMap<>();
+    private final ZoweCicsClient client = new ZoweCicsClient();
 
-    public RealCicsService(String url) {
-        this.url = url;
+    public RealCicsService(String baseUrl) {
+        this.baseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+    }
+
+    public RealCicsService(String baseUrl, Map<String, String> mappings) {
+        this(baseUrl);
+        if (mappings != null) {
+            transactionEndpoints.putAll(mappings);
+        }
+    }
+
+    /** Register a mapping between a CICS transaction and a REST endpoint path. */
+    public void registerTransaction(String transaction, String endpoint) {
+        transactionEndpoints.put(transaction, endpoint);
     }
 
     @Override
     public String invokeTransaction(String transaction, Map<String, Object> payload) {
-        // TODO: Implement real CICS connectivity
-        return "Invoked " + transaction + " at " + url;
+        String endpoint = transactionEndpoints.getOrDefault(transaction, "/api/cics/" + transaction.toLowerCase());
+        String url = baseUrl + endpoint;
+        return client.postJson(url, payload);
     }
 }
-

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/ZoweCicsClient.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/ZoweCicsClient.java
@@ -1,0 +1,51 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import java.io.IOException;
+import java.net.URI;
+import java.net.http.HttpClient;
+import java.net.http.HttpRequest;
+import java.net.http.HttpResponse;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+/**
+ * Minimal HTTP client for invoking CICS transactions exposed via
+ * Zowe/JCICS REST APIs. This implementation keeps dependencies light
+ * by relying solely on {@link java.net.http.HttpClient}.
+ */
+public class ZoweCicsClient {
+
+    private final HttpClient httpClient = HttpClient.newHttpClient();
+
+    /**
+     * POST the given payload as JSON to the specified URL.
+     *
+     * @param url     target endpoint
+     * @param payload map of values to be serialised as JSON
+     * @return response body as plain text
+     */
+    public String postJson(String url, Map<String, Object> payload) {
+        String body = toJson(payload);
+        HttpRequest request = HttpRequest.newBuilder()
+                .uri(URI.create(url))
+                .header("Content-Type", "application/json")
+                .POST(HttpRequest.BodyPublishers.ofString(body))
+                .build();
+        try {
+            HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString());
+            return response.body();
+        } catch (IOException | InterruptedException e) {
+            Thread.currentThread().interrupt();
+            throw new RuntimeException("Failed to invoke CICS endpoint", e);
+        }
+    }
+
+    private String toJson(Map<String, Object> payload) {
+        if (payload == null || payload.isEmpty()) {
+            return "{}";
+        }
+        return payload.entrySet().stream()
+                .map(e -> "\"" + e.getKey() + "\":\"" + String.valueOf(e.getValue()) + "\"")
+                .collect(Collectors.joining(",", "{", "}"));
+    }
+}


### PR DESCRIPTION
## Summary
- wire in Zowe CICS/JCICS client for COBOL provider
- route CICS transactions through mapped REST endpoints
- add manual invocation example in COBOL provider README

## Testing
- `mvn -q -pl renovatio-provider-cobol test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c015664cdc832ebaaeb0bcf63db61a