### PR TITLE
feat: add MapStruct mapping and OpenAPI generator

### DIFF
--- a/renovatio-core/pom.xml
+++ b/renovatio-core/pom.xml
@@ -3,17 +3,17 @@
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
     <modelVersion>4.0.0</modelVersion>
-    
+
     <parent>
         <groupId>org.shark.renovatio</groupId>
         <artifactId>renovatio-parent</artifactId>
         <version>0.0.1-SNAPSHOT</version>
     </parent>
-    
+
     <artifactId>renovatio-core</artifactId>
     <name>Renovatio Core</name>
     <description>MCP protocol core, tool catalog, NQL routing</description>
-    
+
     <dependencies>
         <dependency>
             <groupId>org.shark.renovatio</groupId>
@@ -32,15 +32,47 @@
             <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.mapstruct</groupId>
+            <artifactId>mapstruct-processor</artifactId>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-
         <dependency>
             <groupId>org.apache.pdfbox</groupId>
             <artifactId>pdfbox</artifactId>
             <version>2.0.30</version>
         </dependency>
     </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>7.0.1</version>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>generate</goal>
+                        </goals>
+                        <configuration>
+                            <inputSpec>${project.basedir}/src/main/resources/openapi/user-api.yml</inputSpec>
+                            <generatorName>spring</generatorName>
+                            <output>${project.build.directory}/generated-sources/openapi</output>
+                            <apiPackage>org.shark.renovatio.core.api</apiPackage>
+                            <modelPackage>org.shark.renovatio.core.dto</modelPackage>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/dto/UserDto.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/dto/UserDto.java
@@ -1,0 +1,35 @@
+package org.shark.renovatio.core.dto;
+
+/**
+ * Data transfer object for {@link org.shark.renovatio.core.entity.UserEntity}.
+ */
+public class UserDto {
+
+    private Long id;
+    private String name;
+    private String email;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/entity/UserEntity.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/entity/UserEntity.java
@@ -1,0 +1,35 @@
+package org.shark.renovatio.core.entity;
+
+/**
+ * Simple user entity for demonstrating MapStruct mapping.
+ */
+public class UserEntity {
+
+    private Long id;
+    private String name;
+    private String email;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public String getEmail() {
+        return email;
+    }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
+}

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/mapper/UserMapper.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/mapper/UserMapper.java
@@ -1,0 +1,19 @@
+package org.shark.renovatio.core.mapper;
+
+import org.mapstruct.Mapper;
+import org.mapstruct.factory.Mappers;
+import org.shark.renovatio.core.dto.UserDto;
+import org.shark.renovatio.core.entity.UserEntity;
+
+/**
+ * Mapper for converting between {@link UserEntity} and {@link UserDto}.
+ */
+@Mapper
+public interface UserMapper {
+
+    UserMapper INSTANCE = Mappers.getMapper(UserMapper.class);
+
+    UserDto toDto(UserEntity entity);
+
+    UserEntity toEntity(UserDto dto);
+}

--- a/renovatio-core/src/main/resources/openapi/user-api.yml
+++ b/renovatio-core/src/main/resources/openapi/user-api.yml
@@ -1,0 +1,44 @@
+openapi: 3.0.1
+info:
+  title: User API
+  version: 1.0.0
+paths:
+  /users:
+    get:
+      summary: List users
+      responses:
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/UserDto'
+    post:
+      summary: Create user
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UserDto'
+      responses:
+        '201':
+          description: Created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/UserDto'
+components:
+  schemas:
+    UserDto:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        email:
+          type: string

--- a/templates/README.md
+++ b/templates/README.md
@@ -1,0 +1,7 @@
+# Code Templates
+
+This directory stores reusable templates for code generation tools such as
+Cobigen or OpenAPI Generator. By keeping these templates in the repository,
+changes can be versioned and shared across modules. In a real project, this
+folder could be split into a dedicated Git submodule to allow independent
+versioning.

--- a/templates/controller.mustache
+++ b/templates/controller.mustache
@@ -1,0 +1,14 @@
+package {{packageName}};
+
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users")
+public class {{className}} {
+
+    @GetMapping
+    public List<UserDto> list() {
+        // TODO: implement
+        return Collections.emptyList();
+    }
+}


### PR DESCRIPTION
## Summary
- add User entity, DTO, and MapStruct mapper
- configure OpenAPI generator plugin and example spec
- version code generation templates within repository

## Testing
- `mvn -q -pl renovatio-core test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c0167d8644832e975532206b163311