### PR TITLE
Expose MCP JSON-RPC endpoint at /mcp

### DIFF
--- a/renovatio-core/src/main/java/org/shark/renovatio/core/infrastructure/McpProtocolController.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/infrastructure/McpProtocolController.java
@@ -8,14 +8,14 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/")
+@RequestMapping("/mcp")
 @Tag(name = "MCP Protocol")
 public class McpProtocolController {
 
     @Autowired
     private McpService mcpService;
 
-    @PostMapping("/")
+    @PostMapping
     @Operation(summary = "MCP JSON-RPC 2.0 endpoint")
     public McpResponse handleMcpRequest(@RequestBody McpRequest request) {
         return mcpService.handleMcpRequest(request);


### PR DESCRIPTION
## Summary
- route MCP JSON-RPC requests through `/mcp` so VS Code can discover tools

## Testing
- ⚠️ `mvn -q -pl renovatio-core -am test` *(failed: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2afeb49fc832e877da94c1caac08f