### PR TITLE
feat(cobol): add recipe registry and yaml loader

### DIFF
--- a/renovatio-provider-cobol/pom.xml
+++ b/renovatio-provider-cobol/pom.xml
@@ -23,6 +23,12 @@
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
         </dependency>
+
+        <!-- YAML loader -->
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+        </dependency>
         
         <!-- Java code generation -->
         <dependency>

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipe.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipe.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.provider.cobol.recipe;
+
+/**
+ * Basic contract for COBOL refactoring recipes.
+ */
+public interface CobolRecipe {
+
+    /**
+     * Prepare the recipe and provide a plan of actions.
+     */
+    void plan();
+
+    /**
+     * Apply the recipe to the target source code or resources.
+     */
+    void apply();
+
+    /**
+     * @return human friendly description of what the recipe does
+     */
+    String description();
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipeRegistry.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipeRegistry.java
@@ -1,0 +1,41 @@
+package org.shark.renovatio.provider.cobol.recipe;
+
+import java.util.Collection;
+import java.util.Map;
+import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Registry holding available {@link CobolRecipe} implementations.
+ */
+public class CobolRecipeRegistry {
+
+    private final Map<String, CobolRecipe> recipes = new ConcurrentHashMap<>();
+
+    /**
+     * Register a recipe under the given name.
+     *
+     * @param name   lookup name
+     * @param recipe recipe instance
+     */
+    public void register(String name, CobolRecipe recipe) {
+        recipes.put(name, recipe);
+    }
+
+    /**
+     * Find a recipe by name.
+     *
+     * @param name lookup name
+     * @return recipe or empty if not found
+     */
+    public Optional<CobolRecipe> find(String name) {
+        return Optional.ofNullable(recipes.get(name));
+    }
+
+    /**
+     * @return all registered recipes
+     */
+    public Collection<CobolRecipe> getAll() {
+        return recipes.values();
+    }
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipeYamlLoader.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipeYamlLoader.java
@@ -1,0 +1,50 @@
+package org.shark.renovatio.provider.cobol.recipe;
+
+import org.yaml.snakeyaml.Yaml;
+
+import java.io.InputStream;
+import java.util.Map;
+
+/**
+ * Loads COBOL recipes defined in a YAML file and registers them in a {@link CobolRecipeRegistry}.
+ */
+public class CobolRecipeYamlLoader {
+
+    /**
+     * Load recipes from a YAML resource available on the classpath.
+     *
+     * @param resourceName resource to load, e.g. "cobol-rewrite.yml"
+     * @return registry containing all discovered recipes
+     */
+    public CobolRecipeRegistry load(String resourceName) {
+        CobolRecipeRegistry registry = new CobolRecipeRegistry();
+        Yaml yaml = new Yaml();
+
+        try (InputStream input = getClass().getClassLoader().getResourceAsStream(resourceName)) {
+            if (input == null) {
+                return registry;
+            }
+            Map<String, Object> data = yaml.load(input);
+            Object recipesNode = data.get("recipes");
+            if (recipesNode instanceof Map<?, ?> recipes) {
+                for (Map.Entry<?, ?> entry : recipes.entrySet()) {
+                    String name = String.valueOf(entry.getKey());
+                    String className = String.valueOf(entry.getValue());
+                    try {
+                        Class<?> clazz = Class.forName(className);
+                        if (CobolRecipe.class.isAssignableFrom(clazz)) {
+                            CobolRecipe recipe = (CobolRecipe) clazz.getDeclaredConstructor().newInstance();
+                            registry.register(name, recipe);
+                        }
+                    } catch (Exception ex) {
+                        throw new IllegalArgumentException("Failed to load recipe: " + className, ex);
+                    }
+                }
+            }
+        } catch (Exception e) {
+            throw new IllegalStateException("Unable to load recipes from " + resourceName, e);
+        }
+
+        return registry;
+    }
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/NoOpCobolRecipe.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/recipe/NoOpCobolRecipe.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.provider.cobol.recipe;
+
+/**
+ * Sample recipe used for testing the registry and loader.
+ */
+public class NoOpCobolRecipe implements CobolRecipe {
+
+    @Override
+    public void plan() {
+        // no planning required
+    }
+
+    @Override
+    public void apply() {
+        // nothing to apply
+    }
+
+    @Override
+    public String description() {
+        return "No operation recipe";
+    }
+}

--- a/renovatio-provider-cobol/src/main/resources/cobol-rewrite.yml
+++ b/renovatio-provider-cobol/src/main/resources/cobol-rewrite.yml
@@ -1,0 +1,2 @@
+recipes:
+  noop: org.shark.renovatio.provider.cobol.recipe.NoOpCobolRecipe

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipeYamlLoaderTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/recipe/CobolRecipeYamlLoaderTest.java
@@ -1,0 +1,15 @@
+package org.shark.renovatio.provider.cobol.recipe;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class CobolRecipeYamlLoaderTest {
+
+    @Test
+    void loadsRecipesFromYaml() {
+        CobolRecipeYamlLoader loader = new CobolRecipeYamlLoader();
+        CobolRecipeRegistry registry = loader.load("cobol-rewrite.yml");
+        assertTrue(registry.find("noop").isPresent(), "NoOp recipe should be loaded");
+    }
+}


### PR DESCRIPTION
## Summary
- add `CobolRecipe` interface and basic no-op implementation
- load recipes from `cobol-rewrite.yml` and register them in a `CobolRecipeRegistry`
- wire SnakeYAML for parsing

## Testing
- `mvn -q -pl renovatio-provider-cobol -am test` *(failed: Non-resolvable parent POM; Could not transfer artifact org.springframework.boot:spring-boot-starter-parent)*


------
https://chatgpt.com/codex/tasks/task_e_68c2cdda4854832e88f23590c2b4e49d