### PR TITLE
feat(cobol): build migration plan from recipes

### DIFF
--- a/README.md
+++ b/README.md
@@ -423,7 +423,7 @@ renovatio/
 │   ├── service/                      # Servicios de migración COBOL
 │   │   ├── CobolParsingService.java  # Parsing y análisis COBOL
 │   │   ├── JavaGenerationService.java # Generación de código Java
-│   │   ├── MigrationPlanService.java # Planificación de migración
+│   │   ├── RecipeBasedMigrationPlanService.java # Planificación de migración basada en recetas
 │   │   ├── IndexingService.java      # Indexación Lucene
 │   │   ├── MetricsService.java       # Cálculo de métricas
 │   │   ├── TemplateCodeGenerationService.java # Generación basada en plantillas

--- a/renovatio-provider-cobol/README.md
+++ b/renovatio-provider-cobol/README.md
@@ -111,7 +111,7 @@ renovatio-provider-cobol/
 │   ├── service/                            # Core services
 │   │   ├── CobolParsingService.java        # COBOL parsing and analysis
 │   │   ├── JavaGenerationService.java     # Java code generation
-│   │   ├── MigrationPlanService.java      # Migration planning
+│   │   ├── RecipeBasedMigrationPlanService.java      # Migration planning from recipes
 │   │   ├── IndexingService.java           # Lucene-based indexing
 │   │   ├── MetricsService.java            # Code metrics calculation
 │   │   ├── TemplateCodeGenerationService.java # Template-based generation

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolLanguageProvider.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolLanguageProvider.java
@@ -22,7 +22,7 @@ public class CobolLanguageProvider implements LanguageProvider {
     
     private final CobolParsingService parsingService;
     private final JavaGenerationService javaGenerationService;
-    private final MigrationPlanService migrationPlanService;
+    private final RecipeBasedMigrationPlanService migrationPlanService;
     private final IndexingService indexingService;
     private final MetricsService metricsService;
     private final TemplateCodeGenerationService templateCodeGenerationService;
@@ -31,7 +31,7 @@ public class CobolLanguageProvider implements LanguageProvider {
     public CobolLanguageProvider(
             CobolParsingService parsingService,
             JavaGenerationService javaGenerationService,
-            MigrationPlanService migrationPlanService,
+            RecipeBasedMigrationPlanService migrationPlanService,
             IndexingService indexingService,
             MetricsService metricsService,
             TemplateCodeGenerationService templateCodeGenerationService,

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/infrastructure/CobolProviderConfiguration.java
@@ -28,10 +28,16 @@ public class CobolProviderConfiguration {
     }
     
     @Bean
-    public MigrationPlanService migrationPlanService(
+    public CobolRecipeRegistry cobolRecipeRegistry() {
+        return new CobolRecipeRegistry();
+    }
+
+    @Bean
+    public RecipeBasedMigrationPlanService migrationPlanService(
             CobolParsingService parsingService,
-            JavaGenerationService javaGenerationService) {
-        return new MigrationPlanService(parsingService, javaGenerationService);
+            JavaGenerationService javaGenerationService,
+            CobolRecipeRegistry cobolRecipeRegistry) {
+        return new RecipeBasedMigrationPlanService(parsingService, javaGenerationService, cobolRecipeRegistry);
     }
     
     @Bean
@@ -60,7 +66,7 @@ public class CobolProviderConfiguration {
     public CobolLanguageProvider cobolLanguageProvider(
             CobolParsingService parsingService,
             JavaGenerationService javaGenerationService,
-            MigrationPlanService migrationPlanService,
+            RecipeBasedMigrationPlanService migrationPlanService,
             IndexingService indexingService,
             MetricsService metricsService,
             TemplateCodeGenerationService templateCodeGenerationService,

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CobolRecipeRegistry.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/CobolRecipeRegistry.java
@@ -1,0 +1,62 @@
+package org.shark.renovatio.provider.cobol.service;
+
+import org.springframework.stereotype.Component;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Registry for COBOL migration recipes defined in cobol-rewrite.yml.
+ * Loads the recipe names and exposes them in declaration order.
+ */
+@Component
+public class CobolRecipeRegistry {
+
+    private final List<String> recipes;
+
+    public CobolRecipeRegistry() {
+        this.recipes = loadRecipes();
+    }
+
+    /**
+     * @return immutable list of recipe names in declaration order
+     */
+    public List<String> getRecipes() {
+        return recipes;
+    }
+
+    private List<String> loadRecipes() {
+        Path path = Paths.get("cobol-rewrite.yml");
+        if (!Files.exists(path)) {
+            return Collections.emptyList();
+        }
+        List<String> list = new ArrayList<>();
+        try (BufferedReader reader = Files.newBufferedReader(path)) {
+            String line;
+            boolean inList = false;
+            while ((line = reader.readLine()) != null) {
+                line = line.trim();
+                if (line.startsWith("recipeList")) {
+                    inList = true;
+                    continue;
+                }
+                if (inList) {
+                    if (line.startsWith("-")) {
+                        list.add(line.substring(1).trim());
+                    } else if (!line.isEmpty() && !line.startsWith("#")) {
+                        // any non-list line ends the section
+                        inList = false;
+                    }
+                }
+            }
+        } catch (IOException ignored) {
+        }
+        return List.copyOf(list);
+    }
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/RecipeBasedMigrationPlanService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/RecipeBasedMigrationPlanService.java
@@ -1,75 +1,76 @@
 package org.shark.renovatio.provider.cobol.service;
 
 import org.shark.renovatio.shared.domain.*;
-import org.shark.renovatio.shared.util.BenchmarkUtils;
 import org.shark.renovatio.shared.nql.NqlQuery;
+import org.shark.renovatio.shared.util.BenchmarkUtils;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDateTime;
 import java.util.*;
 
 /**
- * Migration planning service for COBOL to Java transformation
- * Creates execution plans, applies migrations, and generates diffs
+ * Migration planning service that builds execution plans from COBOL recipes.
  */
 @Service
-public class MigrationPlanService {
-    
+public class RecipeBasedMigrationPlanService {
+
     private final CobolParsingService parsingService;
     private final JavaGenerationService javaGenerationService;
+    private final CobolRecipeRegistry recipeRegistry;
     private final Map<String, MigrationPlan> activePlans = new HashMap<>();
     private final Map<String, MigrationRun> completedRuns = new HashMap<>();
-    
-    public MigrationPlanService(CobolParsingService parsingService, JavaGenerationService javaGenerationService) {
+
+    public RecipeBasedMigrationPlanService(CobolParsingService parsingService,
+                                           JavaGenerationService javaGenerationService,
+                                           CobolRecipeRegistry recipeRegistry) {
         this.parsingService = parsingService;
         this.javaGenerationService = javaGenerationService;
+        this.recipeRegistry = recipeRegistry;
     }
-    
+
     /**
-     * Creates a migration plan for COBOL to Java transformation
+     * Creates a migration plan for COBOL to Java transformation using declared recipes.
      */
     public PlanResult createMigrationPlan(NqlQuery query, Scope scope, Workspace workspace) {
         try {
             String planId = UUID.randomUUID().toString();
-            
-            // Analyze COBOL programs in scope
+
             AnalyzeResult analyzeResult = parsingService.analyzeCOBOL(query, workspace);
             if (!analyzeResult.isSuccess()) {
                 return new PlanResult(false, "Failed to analyze COBOL for planning: " + analyzeResult.getMessage());
             }
-            
+
             MigrationPlan plan = new MigrationPlan();
             plan.setId(planId);
             plan.setCreatedAt(LocalDateTime.now());
             plan.setQuery(query);
             plan.setScope(scope);
             plan.setWorkspace(workspace);
-            
-            // Create migration steps
-            List<MigrationStep> steps = createMigrationSteps(analyzeResult, query);
+
+            List<MigrationStep> steps = createMigrationSteps();
             plan.setSteps(steps);
-            
+
             activePlans.put(planId, plan);
-            
+
             PlanResult result = new PlanResult(true, "Migration plan created successfully");
             result.setPlanId(planId);
             result.setPlanContent(generatePlanSummary(plan));
-            
+
             Map<String, Object> stepsMap = new HashMap<>();
             for (int i = 0; i < steps.size(); i++) {
-                stepsMap.put("step" + (i + 1), steps.get(i).getDescription());
+                stepsMap.put("step" + (i + 1), steps.get(i).getRecipe());
             }
             result.setSteps(stepsMap);
-            
+
             return result;
-            
+
         } catch (Exception e) {
             return new PlanResult(false, "Migration planning failed: " + e.getMessage());
         }
     }
-    
+
     /**
-     * Applies a migration plan
+     * Applies a migration plan executing each recipe in order.
      */
     public ApplyResult applyMigrationPlan(String planId, boolean dryRun, Workspace workspace) {
         try {
@@ -77,14 +78,14 @@ public class MigrationPlanService {
             if (plan == null) {
                 return new ApplyResult(false, "Migration plan not found: " + planId);
             }
-            
+
             String runId = UUID.randomUUID().toString();
             MigrationRun run = new MigrationRun();
             run.setId(runId);
             run.setPlanId(planId);
             run.setStartedAt(LocalDateTime.now());
             run.setDryRun(dryRun);
-            
+
             List<String> executedSteps = new ArrayList<>();
             Map<String, String> generatedFiles = new HashMap<>();
 
@@ -92,19 +93,22 @@ public class MigrationPlanService {
 
             long migrationStart = System.nanoTime();
             for (MigrationStep step : plan.getSteps()) {
+                String recipe = step.getRecipe();
                 try {
-                    if (step.getType() == StepType.GENERATE_JAVA_STUBS) {
-                        // Generate Java stubs
+                    // Execute recipes according to simple mapping
+                    if (recipe.contains("ParseCobol")) {
+                        parsingService.analyzeCOBOL(plan.getQuery(), workspace);
+                    } else if (recipe.contains("GenerateJavaDtos")) {
                         StubResult stubResult = javaGenerationService.generateInterfaceStubs(plan.getQuery(), workspace);
                         if (stubResult.isSuccess() && stubResult.getGeneratedCode() != null) {
                             generatedFiles.putAll(stubResult.getGeneratedCode());
                         }
+                    } else if (recipe.contains("GenerateMigrationPlan")) {
+                        // no-op for now
                     }
-
-                    executedSteps.add(step.getDescription());
-
+                    executedSteps.add(recipe);
                 } catch (Exception e) {
-                    run.setError("Failed to execute step: " + step.getDescription() + " - " + e.getMessage());
+                    run.setError("Failed to execute recipe: " + recipe + " - " + e.getMessage());
                     break;
                 }
             }
@@ -129,12 +133,12 @@ public class MigrationPlanService {
             result.setChanges(changes);
 
             return result;
-            
+
         } catch (Exception e) {
             return new ApplyResult(false, "Migration application failed: " + e.getMessage());
         }
     }
-    
+
     /**
      * Generates a diff for a completed migration run
      */
@@ -144,102 +148,62 @@ public class MigrationPlanService {
             if (run == null) {
                 return new DiffResult(false, "Migration run not found: " + runId);
             }
-            
+
             StringBuilder unifiedDiff = new StringBuilder();
             unifiedDiff.append("Migration Run: ").append(runId).append("\n");
             unifiedDiff.append("Plan ID: ").append(run.getPlanId()).append("\n");
             unifiedDiff.append("Started: ").append(run.getStartedAt()).append("\n");
             unifiedDiff.append("Completed: ").append(run.getCompletedAt()).append("\n");
             unifiedDiff.append("\nGenerated Files:\n");
-            
+
             if (run.getGeneratedFiles() != null) {
                 for (Map.Entry<String, String> entry : run.getGeneratedFiles().entrySet()) {
                     unifiedDiff.append("+ ").append(entry.getKey()).append("\n");
                 }
             }
-            
+
             DiffResult result = new DiffResult(true, "Diff generated successfully");
             result.setUnifiedDiff(unifiedDiff.toString());
-            
+
             Map<String, Object> semanticDiff = new HashMap<>();
             semanticDiff.put("addedFiles", run.getGeneratedFiles() != null ? run.getGeneratedFiles().size() : 0);
             semanticDiff.put("modifiedFiles", 0);
             semanticDiff.put("deletedFiles", 0);
             result.setSemanticDiff(semanticDiff);
-            
+
             return result;
-            
+
         } catch (Exception e) {
             return new DiffResult(false, "Diff generation failed: " + e.getMessage());
         }
     }
-    
+
     /**
-     * Creates migration steps based on analysis results
+     * Creates migration steps from registry
      */
-    private List<MigrationStep> createMigrationSteps(AnalyzeResult analyzeResult, NqlQuery query) {
+    private List<MigrationStep> createMigrationSteps() {
         List<MigrationStep> steps = new ArrayList<>();
-        
-        // Step 1: Parse COBOL programs
-        steps.add(new MigrationStep(
-            StepType.PARSE_COBOL,
-            "Parse COBOL programs and extract AST",
-            "Analyze COBOL source code structure"
-        ));
-        
-        // Step 2: Generate Java DTOs
-        steps.add(new MigrationStep(
-            StepType.GENERATE_JAVA_DTOS,
-            "Generate Java DTO classes from COBOL data structures",
-            "Create Java classes representing COBOL data items"
-        ));
-        
-        // Step 3: Generate Java service interfaces
-        steps.add(new MigrationStep(
-            StepType.GENERATE_JAVA_STUBS,
-            "Generate Java service interfaces and implementation templates",
-            "Create Java service layer for COBOL business logic"
-        ));
-        
-        // Step 4: Create migration mapping
-        steps.add(new MigrationStep(
-            StepType.CREATE_MAPPINGS,
-            "Create MapStruct mappings between COBOL and Java structures",
-            "Generate mapping classes for data transformation"
-        ));
-        
-        // Step 5: Generate tests
-        steps.add(new MigrationStep(
-            StepType.GENERATE_TESTS,
-            "Generate unit tests for migrated Java code",
-            "Create test classes to validate migration"
-        ));
-        
+        for (String recipe : recipeRegistry.getRecipes()) {
+            steps.add(new MigrationStep(recipe));
+        }
         return steps;
     }
-    
-    /**
-     * Generates a human-readable plan summary
-     */
+
     private String generatePlanSummary(MigrationPlan plan) {
         StringBuilder summary = new StringBuilder();
         summary.append("COBOL to Java Migration Plan\n");
         summary.append("Plan ID: ").append(plan.getId()).append("\n");
         summary.append("Created: ").append(plan.getCreatedAt()).append("\n");
         summary.append("Steps: ").append(plan.getSteps().size()).append("\n\n");
-        
+
         for (int i = 0; i < plan.getSteps().size(); i++) {
             MigrationStep step = plan.getSteps().get(i);
-            summary.append(i + 1).append(". ").append(step.getDescription()).append("\n");
-            summary.append("   ").append(step.getDetails()).append("\n\n");
+            summary.append(i + 1).append(". ").append(step.getRecipe()).append("\n\n");
         }
-        
         return summary.toString();
     }
-    
-    /**
-     * Migration plan data structure
-     */
+
+    // Internal data structures
     private static class MigrationPlan {
         private String id;
         private LocalDateTime createdAt;
@@ -247,49 +211,27 @@ public class MigrationPlanService {
         private Scope scope;
         private Workspace workspace;
         private List<MigrationStep> steps;
-        
-        // Getters and setters
+
         public String getId() { return id; }
         public void setId(String id) { this.id = id; }
-        
         public LocalDateTime getCreatedAt() { return createdAt; }
         public void setCreatedAt(LocalDateTime createdAt) { this.createdAt = createdAt; }
-        
         public NqlQuery getQuery() { return query; }
         public void setQuery(NqlQuery query) { this.query = query; }
-        
         public Scope getScope() { return scope; }
         public void setScope(Scope scope) { this.scope = scope; }
-        
         public Workspace getWorkspace() { return workspace; }
         public void setWorkspace(Workspace workspace) { this.workspace = workspace; }
-        
         public List<MigrationStep> getSteps() { return steps; }
         public void setSteps(List<MigrationStep> steps) { this.steps = steps; }
     }
-    
-    /**
-     * Migration step data structure
-     */
+
     private static class MigrationStep {
-        private StepType type;
-        private String description;
-        private String details;
-        
-        public MigrationStep(StepType type, String description, String details) {
-            this.type = type;
-            this.description = description;
-            this.details = details;
-        }
-        
-        public StepType getType() { return type; }
-        public String getDescription() { return description; }
-        public String getDetails() { return details; }
+        private final String recipe;
+        public MigrationStep(String recipe) { this.recipe = recipe; }
+        public String getRecipe() { return recipe; }
     }
-    
-    /**
-     * Migration run data structure
-     */
+
     private static class MigrationRun {
         private String id;
         private String planId;
@@ -299,41 +241,22 @@ public class MigrationPlanService {
         private List<String> executedSteps;
         private Map<String, String> generatedFiles;
         private String error;
-        
-        // Getters and setters
+
         public String getId() { return id; }
         public void setId(String id) { this.id = id; }
-        
         public String getPlanId() { return planId; }
         public void setPlanId(String planId) { this.planId = planId; }
-        
         public LocalDateTime getStartedAt() { return startedAt; }
         public void setStartedAt(LocalDateTime startedAt) { this.startedAt = startedAt; }
-        
         public LocalDateTime getCompletedAt() { return completedAt; }
         public void setCompletedAt(LocalDateTime completedAt) { this.completedAt = completedAt; }
-        
         public boolean isDryRun() { return dryRun; }
         public void setDryRun(boolean dryRun) { this.dryRun = dryRun; }
-        
         public List<String> getExecutedSteps() { return executedSteps; }
         public void setExecutedSteps(List<String> executedSteps) { this.executedSteps = executedSteps; }
-        
         public Map<String, String> getGeneratedFiles() { return generatedFiles; }
         public void setGeneratedFiles(Map<String, String> generatedFiles) { this.generatedFiles = generatedFiles; }
-        
         public String getError() { return error; }
         public void setError(String error) { this.error = error; }
-    }
-    
-    /**
-     * Migration step types
-     */
-    private enum StepType {
-        PARSE_COBOL,
-        GENERATE_JAVA_DTOS,
-        GENERATE_JAVA_STUBS,
-        CREATE_MAPPINGS,
-        GENERATE_TESTS
     }
 }

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/ResilientMigrationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/ResilientMigrationService.java
@@ -17,12 +17,12 @@ public class ResilientMigrationService {
     
     private final CobolParsingService parsingService;
     private final JavaGenerationService javaGenerationService;
-    private final MigrationPlanService migrationPlanService;
+    private final RecipeBasedMigrationPlanService migrationPlanService;
     
     public ResilientMigrationService(
             CobolParsingService parsingService,
             JavaGenerationService javaGenerationService,
-            MigrationPlanService migrationPlanService) {
+            RecipeBasedMigrationPlanService migrationPlanService) {
         this.parsingService = parsingService;
         this.javaGenerationService = javaGenerationService;
         this.migrationPlanService = migrationPlanService;

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/CobolLanguageProviderTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/CobolLanguageProviderTest.java
@@ -31,7 +31,9 @@ class CobolLanguageProviderTest {
         JavaGenerationService javaGenerationService = new JavaGenerationService(parsingService);
         TemplateCodeGenerationService templateService = new TemplateCodeGenerationService();
         Db2MigrationService db2Service = new Db2MigrationService(parsingService);
-        MigrationPlanService migrationPlanService = new MigrationPlanService(parsingService, javaGenerationService);
+        CobolRecipeRegistry recipeRegistry = new CobolRecipeRegistry();
+        RecipeBasedMigrationPlanService migrationPlanService =
+                new RecipeBasedMigrationPlanService(parsingService, javaGenerationService, recipeRegistry);
         IndexingService indexingService = new IndexingService();
         MetricsService metricsService = new MetricsService();
 

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/CopybookMigrationToolTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/CopybookMigrationToolTest.java
@@ -25,7 +25,9 @@ public class CopybookMigrationToolTest {
         JavaGenerationService javaGenerationService = new JavaGenerationService(parsingService);
         TemplateCodeGenerationService templateService = new TemplateCodeGenerationService();
         Db2MigrationService db2Service = new Db2MigrationService(parsingService);
-        MigrationPlanService migrationPlanService = new MigrationPlanService(parsingService, javaGenerationService);
+        CobolRecipeRegistry recipeRegistry = new CobolRecipeRegistry();
+        RecipeBasedMigrationPlanService migrationPlanService =
+                new RecipeBasedMigrationPlanService(parsingService, javaGenerationService, recipeRegistry);
         IndexingService indexingService = new IndexingService();
         MetricsService metricsService = new MetricsService();
         CobolLanguageProvider provider = new CobolLanguageProvider(

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/Db2MigrationToolTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/service/Db2MigrationToolTest.java
@@ -32,7 +32,9 @@ public class Db2MigrationToolTest {
         JavaGenerationService javaGenerationService = new JavaGenerationService(parsingService);
         TemplateCodeGenerationService templateService = new TemplateCodeGenerationService();
         Db2MigrationService db2Service = new Db2MigrationService(parsingService);
-        MigrationPlanService migrationPlanService = new MigrationPlanService(parsingService, javaGenerationService);
+        CobolRecipeRegistry recipeRegistry = new CobolRecipeRegistry();
+        RecipeBasedMigrationPlanService migrationPlanService =
+                new RecipeBasedMigrationPlanService(parsingService, javaGenerationService, recipeRegistry);
         IndexingService indexingService = new IndexingService();
         MetricsService metricsService = new MetricsService();
         CobolLanguageProvider provider = new CobolLanguageProvider(


### PR DESCRIPTION
## Summary
- load COBOL migration steps from cobol-rewrite.yml via new CobolRecipeRegistry
- execute recipes sequentially using RecipeBasedMigrationPlanService
- wire new service into CobolLanguageProvider and configuration

## Testing
- `mvn -q -pl renovatio-provider-cobol -am test` *(fails: Non-resolvable parent POM: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2cdfb8330832e825e8be5b1e12762