### PR TITLE
refactor: add base language provider

### DIFF
--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolLanguageProvider.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolLanguageProvider.java
@@ -1,6 +1,6 @@
 package org.shark.renovatio.provider.cobol;
 
-import org.shark.renovatio.shared.spi.LanguageProvider;
+import org.shark.renovatio.shared.spi.BaseLanguageProvider;
 import org.shark.renovatio.shared.domain.*;
 import org.shark.renovatio.shared.nql.NqlQuery;
 import org.shark.renovatio.provider.cobol.service.*;
@@ -15,7 +15,7 @@ import java.nio.file.Paths;
  * Implements parsing, analysis, code generation and migration capabilities
  */
 @Component
-public class CobolLanguageProvider implements LanguageProvider {
+public class CobolLanguageProvider extends BaseLanguageProvider {
     
     private final CobolParsingService parsingService;
     private final JavaGenerationService javaGenerationService;

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolProvider.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolProvider.java
@@ -1,6 +1,6 @@
 package org.shark.renovatio.provider.cobol;
 
-import org.shark.renovatio.shared.spi.LanguageProvider;
+import org.shark.renovatio.shared.spi.BaseLanguageProvider;
 import org.shark.renovatio.shared.domain.*;
 import org.shark.renovatio.shared.nql.NqlQuery;
 import org.shark.renovatio.provider.cobol.service.CobolParsingService;
@@ -15,7 +15,7 @@ import java.util.*;
  * COBOL language provider implementation using real COBOL file analysis
  */
 @Component
-public class CobolProvider implements LanguageProvider {
+public class CobolProvider extends BaseLanguageProvider {
     
     private final CobolParsingService parsingService;
 
@@ -89,7 +89,7 @@ public class CobolProvider implements LanguageProvider {
         result.setRunId(runId);
         
         // Would use GumTree for semantic diffs as mentioned in requirements
-        String unifiedDiff = createSampleCobolDiff();
+        String unifiedDiff = createSampleDiff();
         result.setUnifiedDiff(unifiedDiff);
         
         Map<String, Object> semanticDiff = new HashMap<>();
@@ -164,25 +164,6 @@ public class CobolProvider implements LanguageProvider {
         return Dialect.fromString(value);
     }
     
-    private String generateRunId() {
-        return "cobol-run-" + System.currentTimeMillis();
-    }
-    
-    private String createSampleCobolDiff() {
-        return """
-            --- a/CUSTOMER-PROG.cbl
-            +++ b/CUSTOMER-PROG.cbl
-            @@ -15,6 +15,8 @@
-                 01  WS-CUSTOMER-RECORD.
-                     05  WS-CUSTOMER-ID      PIC 9(6).
-                     05  WS-CUSTOMER-NAME    PIC X(30).
-            +        05  WS-CUSTOMER-EMAIL   PIC X(50).
-            +        05  WS-CUSTOMER-PHONE   PIC X(15).
-                 
-                 PROCEDURE DIVISION.
-                 MAIN-PARA.
-            """;
-    }
     
     private String generateCustomerRecordStub() {
         return """

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaLanguageProvider.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaLanguageProvider.java
@@ -1,13 +1,13 @@
 package org.shark.renovatio.provider.java;
 
-import org.shark.renovatio.shared.spi.LanguageProvider;
+import org.shark.renovatio.shared.spi.BaseLanguageProvider;
 import org.shark.renovatio.shared.domain.*;
 import org.shark.renovatio.shared.nql.NqlQuery;
 import java.util.EnumSet;
 import java.util.Optional;
 import java.util.Set;
 
-public class JavaLanguageProvider implements LanguageProvider {
+public class JavaLanguageProvider extends BaseLanguageProvider {
     public JavaLanguageProvider() {}
 
     @Override

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaProvider.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaProvider.java
@@ -1,6 +1,6 @@
 package org.shark.renovatio.provider.java;
 
-import org.shark.renovatio.shared.spi.LanguageProvider;
+import org.shark.renovatio.shared.spi.BaseLanguageProvider;
 import org.shark.renovatio.shared.domain.*;
 import org.shark.renovatio.shared.nql.NqlQuery;
 import org.springframework.stereotype.Component;
@@ -11,7 +11,7 @@ import java.util.*;
  * Java language provider implementation using OpenRewrite
  */
 @Component
-public class JavaProvider implements LanguageProvider {
+public class JavaProvider extends BaseLanguageProvider {
     
     @Override
     public String language() {
@@ -139,29 +139,4 @@ public class JavaProvider implements LanguageProvider {
         return result;
     }
     
-    private String generateRunId() {
-        return "java-run-" + System.currentTimeMillis();
-    }
-    
-    private String generatePlanId() {
-        return "java-plan-" + System.currentTimeMillis();
-    }
-    
-    private String createSampleDiff() {
-        return """
-            --- a/src/main/java/Example.java
-            +++ b/src/main/java/Example.java
-            @@ -1,8 +1,10 @@
-             public class Example {
-            -    private String name = null;
-            +    private String name;
-                 
-                 public void process() {
-            +        // Added validation
-            +        if (name == null) return;
-                     System.out.println("Processing: " + name);
-                 }
-             }
-            """;
-    }
 }

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/spi/BaseLanguageProvider.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/spi/BaseLanguageProvider.java
@@ -1,0 +1,41 @@
+package org.shark.renovatio.shared.spi;
+
+/**
+ * Base class for language providers offering common utility methods.
+ */
+public abstract class BaseLanguageProvider implements LanguageProvider {
+
+    /**
+     * Generate a run identifier using the provider's language prefix.
+     *
+     * @return run identifier unique to this execution
+     */
+    protected String generateRunId() {
+        return language() + "-run-" + System.currentTimeMillis();
+    }
+
+    /**
+     * Generate a plan identifier using the provider's language prefix.
+     *
+     * @return plan identifier unique to this plan creation
+     */
+    protected String generatePlanId() {
+        return language() + "-plan-" + System.currentTimeMillis();
+    }
+
+    /**
+     * Create a sample unified diff. Concrete implementations may override
+     * this method to provide language specific examples.
+     *
+     * @return a simple unified diff string
+     */
+    protected String createSampleDiff() {
+        return """
+            --- a/example.txt
+            +++ b/example.txt
+            @@ -1 +1 @@
+            -old line
+            +new line
+            """;
+    }
+}


### PR DESCRIPTION
## Summary
- introduce `BaseLanguageProvider` with common run/plan id and diff helpers
- extend Java and COBOL providers from the new base class
- update other provider implementations to reuse the shared utilities

## Testing
- `mvn -q -e -pl renovatio-shared,renovatio-provider-java,renovatio-provider-cobol test` *(failed: Non-resolvable parent POM - Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e893b3ec832ebc918e0b66f3f736