### PR TITLE
feat: load tools from configuration

### DIFF
--- a/src/main/java/org/shark/renovatio/McpServerApplication.java
+++ b/src/main/java/org/shark/renovatio/McpServerApplication.java
@@ -9,7 +9,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.shark.renovatio.application.McpToolingService;
-import org.shark.renovatio.domain.Tool;
+import org.shark.renovatio.domain.ToolDefinition;
 
 @SpringBootApplication
 @OpenAPIDefinition(info = @Info(title = "Renovatio API", version = "1.0", description = "API para refactorización con OpenRewrite"))
@@ -25,7 +25,7 @@ public class McpServerApplication {
         return args -> {
             System.out.println("\n================ MCP Server iniciado ================");
             System.out.println("Tools publicadas:");
-            for (Tool tool : mcpToolingService.getTools()) {
+            for (ToolDefinition tool : mcpToolingService.getTools()) {
                 System.out.printf("- %s: %s\n", tool.getName(), tool.getDescription());
             }
             System.out.println("\nURLs de conexión para configurar el cliente:");

--- a/src/main/java/org/shark/renovatio/domain/ToolDefinition.java
+++ b/src/main/java/org/shark/renovatio/domain/ToolDefinition.java
@@ -3,7 +3,7 @@ package org.shark.renovatio.domain;
 import io.swagger.v3.oas.annotations.media.Schema;
 
 @Schema(description = "Definición de una herramienta MCP")
-public class Tool {
+public class ToolDefinition {
     @Schema(description = "Nombre único de la herramienta")
     private String name;
     @Schema(description = "Descripción de la herramienta")

--- a/src/main/java/org/shark/renovatio/infrastructure/McpController.java
+++ b/src/main/java/org/shark/renovatio/infrastructure/McpController.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.tags.Tag;
 import org.shark.renovatio.application.McpToolingService;
 import org.shark.renovatio.domain.RefactorRequest;
 import org.shark.renovatio.domain.RefactorResponse;
-import org.shark.renovatio.domain.Tool;
+import org.shark.renovatio.domain.ToolDefinition;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.web.bind.annotation.*;
 
@@ -28,7 +28,7 @@ public class McpController {
 
     @GetMapping("/tools")
     @Operation(summary = "Lista las herramientas disponibles")
-    public List<Tool> listTools() {
+    public List<ToolDefinition> listTools() {
         return mcpToolingService.getTools();
     }
 
@@ -86,7 +86,7 @@ public class McpController {
     @GetMapping("/run/{toolName}")
     @Operation(summary = "Devuelve la definición de una herramienta específica")
     public Object getToolDefinition(@PathVariable String toolName) {
-        Tool found = mcpToolingService.getTools().stream()
+        ToolDefinition found = mcpToolingService.getTools().stream()
             .filter(t -> t.getName().equalsIgnoreCase(toolName))
             .findFirst().orElse(null);
         if (found == null) {

--- a/src/main/resources/tools.json
+++ b/src/main/resources/tools.json
@@ -1,0 +1,20 @@
+[
+  {"name": "org.openrewrite.java.format.AutoFormat", "description": "Automatically format Java code", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.UnnecessaryParentheses", "description": "Remove unnecessary parentheses", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.EmptyBlock", "description": "Remove empty blocks", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.ExplicitInitialization", "description": "Remove explicit initialization of variables to default values", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.FinalizePrivateFields", "description": "Finalize private fields that are not reassigned", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.BigDecimalRoundingConstantsToEnums", "description": "Replace BigDecimal rounding constants with enums", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.BooleanChecksNotInverted", "description": "Replace inverted boolean checks", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.CaseInsensitiveComparisonsDoNotChangeCase", "description": "Use case-insensitive comparison methods", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.ChainStringBuilderAppendCalls", "description": "Chain StringBuilder append calls", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.cleanup.CovariantEquals", "description": "Use covariant equals", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.migrate.Java8toJava11", "description": "Migrate from Java 8 to Java 11", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.migrate.JavaVersion11", "description": "Upgrade to Java 11", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.migrate.JavaVersion17", "description": "Upgrade to Java 17", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.migrate.JavaVersion21", "description": "Upgrade to Java 21", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.security.FindJdbcUrl", "description": "Find JDBC URLs", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.security.FindSqlInjection", "description": "Find potential SQL injection vulnerabilities", "command": "openrewrite"},
+  {"name": "org.openrewrite.java.security.SecureRandomPrefersDefaultSeed", "description": "Use SecureRandom with default seed", "command": "openrewrite"}
+]
+


### PR DESCRIPTION
## Summary
- add ToolDefinition domain model
- load tool definitions from tools.json instead of hardcoded list
- expose tool definitions through controller and server startup

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM - network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e891ef18832e9dc11565b6bcc6f7