### PR TITLE
refactor: delegate basic refactorings to recipe handlers

### DIFF
--- a/src/main/java/org/shark/renovatio/application/RefactorService.java
+++ b/src/main/java/org/shark/renovatio/application/RefactorService.java
@@ -1,11 +1,20 @@
 package org.shark.renovatio.application;
 
+import java.util.Map;
+
 import org.springframework.stereotype.Service;
+import org.shark.renovatio.application.recipes.RecipeHandler;
 import org.shark.renovatio.domain.RefactorRequest;
 import org.shark.renovatio.domain.RefactorResponse;
 
 @Service
 public class RefactorService {
+
+    private final Map<String, RecipeHandler> handlers;
+
+    public RefactorService(Map<String, RecipeHandler> handlers) {
+        this.handlers = handlers;
+    }
 
     public RefactorResponse refactor(RefactorRequest request) {
         try {
@@ -21,44 +30,10 @@ public class RefactorService {
     }
     
     private String applyBasicRefactoring(String sourceCode, String recipe) {
-        // Apply some basic transformations based on the recipe type
-        switch (recipe) {
-            case "org.openrewrite.java.format.AutoFormat":
-                return formatCode(sourceCode);
-            case "org.openrewrite.java.cleanup.UnnecessaryParentheses":
-                return removeUnnecessaryParentheses(sourceCode);
-            case "org.openrewrite.java.cleanup.EmptyBlock":
-                return removeEmptyBlocks(sourceCode);
-            case "org.openrewrite.java.cleanup.ExplicitInitialization":
-                return removeExplicitInitialization(sourceCode);
-            default:
-                return sourceCode + "\n// Applied recipe: " + recipe;
+        RecipeHandler handler = handlers.get(recipe);
+        if (handler != null) {
+            return handler.apply(sourceCode);
         }
-    }
-    
-    private String formatCode(String code) {
-        // Basic formatting
-        return code.replaceAll("\\{\\s*\\}", "{ }")
-                  .replaceAll("\\s+", " ")
-                  .replaceAll(";\\s*", ";\n    ")
-                  .replaceAll("\\{\\s*", " {\n    ")
-                  .replaceAll("\\}\\s*", "\n}");
-    }
-    
-    private String removeUnnecessaryParentheses(String code) {
-        // Remove some obvious unnecessary parentheses
-        return code.replaceAll("\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)", "$1");
-    }
-    
-    private String removeEmptyBlocks(String code) {
-        // Remove empty blocks
-        return code.replaceAll("\\{\\s*\\}", "");
-    }
-    
-    private String removeExplicitInitialization(String code) {
-        // Remove explicit initialization to default values
-        return code.replaceAll("(\\w+\\s+\\w+)\\s*=\\s*null;", "$1;")
-                  .replaceAll("(int\\s+\\w+)\\s*=\\s*0;", "$1;")
-                  .replaceAll("(boolean\\s+\\w+)\\s*=\\s*false;", "$1;");
+        return sourceCode + "\n// Applied recipe: " + recipe;
     }
 }

--- a/src/main/java/org/shark/renovatio/application/recipes/AutoFormatHandler.java
+++ b/src/main/java/org/shark/renovatio/application/recipes/AutoFormatHandler.java
@@ -1,0 +1,15 @@
+package org.shark.renovatio.application.recipes;
+
+import org.springframework.stereotype.Component;
+
+@Component("org.openrewrite.java.format.AutoFormat")
+public class AutoFormatHandler implements RecipeHandler {
+    @Override
+    public String apply(String code) {
+        return code.replaceAll("\\{\\s*\\}", "{ }")
+                .replaceAll("\\s+", " ")
+                .replaceAll(";\\s*", ";\n    ")
+                .replaceAll("\\{\\s*", " {\n    ")
+                .replaceAll("\\}\\s*", "\n}");
+    }
+}

--- a/src/main/java/org/shark/renovatio/application/recipes/EmptyBlockHandler.java
+++ b/src/main/java/org/shark/renovatio/application/recipes/EmptyBlockHandler.java
@@ -1,0 +1,11 @@
+package org.shark.renovatio.application.recipes;
+
+import org.springframework.stereotype.Component;
+
+@Component("org.openrewrite.java.cleanup.EmptyBlock")
+public class EmptyBlockHandler implements RecipeHandler {
+    @Override
+    public String apply(String code) {
+        return code.replaceAll("\\{\\s*\\}", "");
+    }
+}

--- a/src/main/java/org/shark/renovatio/application/recipes/ExplicitInitializationHandler.java
+++ b/src/main/java/org/shark/renovatio/application/recipes/ExplicitInitializationHandler.java
@@ -1,0 +1,13 @@
+package org.shark.renovatio.application.recipes;
+
+import org.springframework.stereotype.Component;
+
+@Component("org.openrewrite.java.cleanup.ExplicitInitialization")
+public class ExplicitInitializationHandler implements RecipeHandler {
+    @Override
+    public String apply(String code) {
+        return code.replaceAll("(\\w+\\s+\\w+)\\s*=\\s*null;", "$1;")
+                .replaceAll("(int\\s+\\w+)\\s*=\\s*0;", "$1;")
+                .replaceAll("(boolean\\s+\\w+)\\s*=\\s*false;", "$1;");
+    }
+}

--- a/src/main/java/org/shark/renovatio/application/recipes/RecipeHandler.java
+++ b/src/main/java/org/shark/renovatio/application/recipes/RecipeHandler.java
@@ -1,0 +1,5 @@
+package org.shark.renovatio.application.recipes;
+
+public interface RecipeHandler {
+    String apply(String source);
+}

--- a/src/main/java/org/shark/renovatio/application/recipes/UnnecessaryParenthesesHandler.java
+++ b/src/main/java/org/shark/renovatio/application/recipes/UnnecessaryParenthesesHandler.java
@@ -1,0 +1,11 @@
+package org.shark.renovatio.application.recipes;
+
+import org.springframework.stereotype.Component;
+
+@Component("org.openrewrite.java.cleanup.UnnecessaryParentheses")
+public class UnnecessaryParenthesesHandler implements RecipeHandler {
+    @Override
+    public String apply(String code) {
+        return code.replaceAll("\\(([a-zA-Z_][a-zA-Z0-9_]*)\\)", "$1");
+    }
+}


### PR DESCRIPTION
## Summary
- add RecipeHandler interface and recipe-specific handler components
- refactor RefactorService to delegate to handler map instead of switch

## Testing
- `mvn -q test` *(fails: Non-resolvable parent POM; network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_68c2e88fec24832e999a76f8dd461803