### PR TITLE
Ensure MCP tool responses return type/text list

### DIFF
--- a/renovatio-core/src/main/java/org/shark/renovatio/core/application/McpService.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/application/McpService.java
@@ -4,6 +4,7 @@ import org.shark.renovatio.core.mcp.*;
 import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -103,9 +104,16 @@ public class McpService {
         String toolName = (String) params.get("name");
         @SuppressWarnings("unchecked")
         Map<String, Object> arguments = (Map<String, Object>) params.get("arguments");
-        var response = mcpToolingService.executeTool(toolName, arguments);
+
+        Map<String, Object> rawResponse = mcpToolingService.executeTool(toolName, arguments);
+        Map<String, Object> response = new HashMap<>();
+        Object type = rawResponse.get("type");
+        Object text = rawResponse.get("text");
+        response.put("type", type != null ? type : "text");
+        response.put("text", text != null ? text.toString() : rawResponse.toString());
+
         Map<String, Object> result = new HashMap<>();
-        result.put("content", response);
+        result.put("content", List.of(response));
         return new McpResponse(request.getId(), result);
     }
 


### PR DESCRIPTION
## Summary
- Wrap tool call output in a list
- Normalize tool responses to `{"type":..., "text":...}` schema

## Testing
- `mvn -q -pl renovatio-core -am test` *(fails: Non-resolvable parent POM for org.shark.renovatio:renovatio-parent:0.0.1-SNAPSHOT: The following artifacts could not be resolved: org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 (absent): Could not transfer artifact org.springframework.boot:spring-boot-starter-parent:pom:3.2.5 from/to central (https://repo.maven.apache.org/maven2): Network is unreachable and 'parent.relativePath' points at no local POM)*

------
https://chatgpt.com/codex/tasks/task_e_68c30bd1fff0832e8ef2d41f0d4ff978