### PR TITLE
feat: expose cli manifest commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ curl -X POST -H "Content-Type: application/json" \
   http://localhost:8181/
 ```
 
-La respuesta incluye un objeto `commands` con elementos que exponen los campos `name`, `description` e `inputSchema`:
+La respuesta genera un objeto `commands` a partir de cada `McpTool`, exponiendo los campos `name`, `description` e `inputSchema`:
 
 ```json
 {

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/application/McpService.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/application/McpService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.stream.Collectors;
 
 @Service
 public class McpService {
@@ -57,6 +58,8 @@ public class McpService {
                     return handleResourcesList(request);
                 case "resources/read":
                     return handleResourcesRead(request);
+                case "cli/manifest":
+                    return handleCliManifest(request);
                 default:
                     return new McpResponse(request.getId(),
                         new McpError(-32601, "Method not found: " + request.getMethod()));
@@ -152,6 +155,21 @@ public class McpService {
         }
         Map<String, Object> result = new HashMap<>();
         result.put("resource", resource);
+        return new McpResponse(request.getId(), result);
+    }
+
+    private McpResponse handleCliManifest(McpRequest request) {
+        List<McpTool> tools = mcpToolingService.getMcpTools();
+        List<Map<String, Object>> commands = tools.stream().map(tool -> {
+            Map<String, Object> command = new HashMap<>();
+            command.put("name", tool.getName());
+            command.put("description", tool.getDescription());
+            command.put("inputSchema", tool.getInputSchema());
+            return command;
+        }).collect(Collectors.toList());
+
+        Map<String, Object> result = new HashMap<>();
+        result.put("commands", commands);
         return new McpResponse(request.getId(), result);
     }
 

--- a/renovatio-core/src/test/java/org/shark/renovatio/core/application/McpServiceTest.java
+++ b/renovatio-core/src/test/java/org/shark/renovatio/core/application/McpServiceTest.java
@@ -1,0 +1,38 @@
+package org.shark.renovatio.core.application;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.core.mcp.McpRequest;
+import org.shark.renovatio.core.mcp.McpResponse;
+import org.shark.renovatio.core.mcp.McpTool;
+
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+class McpServiceTest {
+
+    @Test
+    void cliManifestIncludesCommandsFromTools() {
+        McpToolingService toolingService = mock(McpToolingService.class);
+        McpTool tool = new McpTool("test.tool", "test description", Map.of("type", "object"));
+        when(toolingService.getMcpTools()).thenReturn(List.of(tool));
+
+        McpService service = new McpService(toolingService);
+        McpRequest request = new McpRequest("1", "cli/manifest", Map.of());
+        McpResponse response = service.handleMcpRequest(request);
+
+        assertNull(response.getError());
+        @SuppressWarnings("unchecked")
+        Map<String, Object> result = (Map<String, Object>) response.getResult();
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> commands = (List<Map<String, Object>>) result.get("commands");
+        assertEquals(1, commands.size());
+        Map<String, Object> command = commands.get(0);
+        assertEquals("test.tool", command.get("name"));
+        assertEquals("test description", command.get("description"));
+        assertEquals(Map.of("type", "object"), command.get("inputSchema"));
+    }
+}
+


### PR DESCRIPTION
## Summary
- expose `cli/manifest` RPC method returning commands derived from registered MCP tools
- document CLI manifest structure and add unit test for commands output

## Testing
- `mvn -q -pl renovatio-core -am test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68c30d6b1cac832e903abb7ee75b52c3