### PR TITLE
Make MCP tooling name handling generic

### DIFF
--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/McpTool.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/McpTool.java
@@ -10,15 +10,18 @@ public class McpTool {
     private String name;
     private String description;
     private Map<String, Object> inputSchema;
+    private Map<String, Object> outputSchema;
     private List<Map<String, Object>> parameters;
     private Map<String, Object> example;
 
     public McpTool() {}
 
-    public McpTool(String name, String description, Map<String, Object> inputSchema, List<Map<String, Object>> parameters, Map<String, Object> example) {
+    public McpTool(String name, String description, Map<String, Object> inputSchema, Map<String, Object> outputSchema,
+                   List<Map<String, Object>> parameters, Map<String, Object> example) {
         this.name = name;
         this.description = description;
         this.inputSchema = inputSchema;
+        this.outputSchema = outputSchema;
         this.parameters = parameters;
         this.example = example;
     }
@@ -47,6 +50,14 @@ public class McpTool {
         this.inputSchema = inputSchema;
     }
 
+    public Map<String, Object> getOutputSchema() {
+        return outputSchema;
+    }
+
+    public void setOutputSchema(Map<String, Object> outputSchema) {
+        this.outputSchema = outputSchema;
+    }
+
     public List<Map<String, Object>> getParameters() {
         return parameters;
     }
@@ -69,6 +80,7 @@ public class McpTool {
                 "name='" + name + '\'' +
                 ", description='" + description + '\'' +
                 ", inputSchema=" + inputSchema +
+                ", outputSchema=" + outputSchema +
                 ", parameters=" + parameters +
                 ", example=" + example +
                 '}';

--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/TextContent.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/TextContent.java
@@ -1,0 +1,24 @@
+package org.shark.renovatio.mcp.server.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.Objects;
+
+/**
+ * Simple MCP content part representing a piece of text that can be returned to the client.
+ */
+public record TextContent(String type, String text) {
+
+    public static final String TEXT_TYPE = "text";
+
+    @JsonCreator
+    public TextContent(@JsonProperty("type") String type, @JsonProperty("text") String text) {
+        this.type = type != null ? type : TEXT_TYPE;
+        this.text = Objects.requireNonNullElse(text, "");
+    }
+
+    public TextContent(String text) {
+        this(TEXT_TYPE, text);
+    }
+}

--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/ToolCallResult.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/ToolCallResult.java
@@ -1,0 +1,32 @@
+package org.shark.renovatio.mcp.server.model;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+import java.util.List;
+import java.util.Objects;
+
+/**
+ * Wrapper for tool execution results returned to MCP clients.
+ */
+public record ToolCallResult(@JsonProperty("content") List<TextContent> content,
+                             @JsonProperty("structuredContent") Object structuredContent,
+                             @JsonProperty("isError") boolean isError) {
+
+    @JsonCreator
+    public ToolCallResult {
+        content = Objects.requireNonNullElse(content, List.of(new TextContent("")));
+    }
+
+    public static ToolCallResult ok(String summary, Object structured) {
+        return new ToolCallResult(List.of(new TextContent(summary)), structured, false);
+    }
+
+    public static ToolCallResult error(String message) {
+        return new ToolCallResult(List.of(new TextContent(message)), null, true);
+    }
+
+    public static ToolCallResult error(String message, Object structured) {
+        return new ToolCallResult(List.of(new TextContent(message)), structured, true);
+    }
+}


### PR DESCRIPTION
## Summary
- keep provider-supplied tool identifiers intact while still enriching schemas and exposing the optional java_analyze output schema
- normalize dot/underscore conversion across the tooling, protocol, and stdio layers so MCP calls use canonical names yet surface human-readable summaries
- relax the language registry to split tool names on the first dot, preserving the remainder for capabilities and recipes

## Testing
- `mvn -pl renovatio-mcp-server test` *(fails: Maven cannot reach central repository in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68cead23eeb4832e84add8367978e504