### PR TITLE
Fix OpenRewrite MCP tool schemas

### DIFF
--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpToolingService.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpToolingService.java
@@ -592,7 +592,9 @@ public class McpToolingService {
         if (idx < 0) {
             return toolName;
         }
-        return toolName.substring(0, idx) + '.' + toolName.substring(idx + 1);
+        String language = toolName.substring(0, idx);
+        String remainder = toolName.substring(idx + 1).replace('_', '.');
+        return language + '.' + remainder;
     }
 
     private String toCanonicalName(String toolName) {
@@ -603,6 +605,8 @@ public class McpToolingService {
         if (idx < 0) {
             return toolName;
         }
-        return toolName.substring(0, idx) + '.' + toolName.substring(idx + 1);
+        String language = toolName.substring(0, idx);
+        String remainder = toolName.substring(idx + 1).replace('_', '.');
+        return language + '.' + remainder;
     }
 }


### PR DESCRIPTION
## Summary
- build JSON schemas for dynamically discovered OpenRewrite recipe tools so MCP clients receive workspace paths and recipe option parameters
- normalize MCP tool schemas before publishing and ensure workspace paths are required for provider-specific tools
- restore dot-separated tool names when routing tool calls so OpenRewrite recipes resolve correctly

## Testing
- mvn -q -pl renovatio-mcp-server,renovatio-provider-java -am test *(fails: Non-resolvable parent POM; Maven Central unreachable in sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68cfff3d9580832e9afb497e5c4c05fe