### PR TITLE
Expose MCP tool metadata and adapt conversions

### DIFF
--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/McpTool.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/model/McpTool.java
@@ -1,5 +1,6 @@
 package org.shark.renovatio.mcp.server.model;
 
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
@@ -13,17 +14,26 @@ public class McpTool {
     private Map<String, Object> outputSchema;
     private List<Map<String, Object>> parameters;
     private Map<String, Object> example;
+    private Map<String, Object> metadata;
 
-    public McpTool() {}
+    public McpTool() {
+        this.metadata = new LinkedHashMap<>();
+    }
 
     public McpTool(String name, String description, Map<String, Object> inputSchema, Map<String, Object> outputSchema,
                    List<Map<String, Object>> parameters, Map<String, Object> example) {
+        this(name, description, inputSchema, outputSchema, parameters, example, null);
+    }
+
+    public McpTool(String name, String description, Map<String, Object> inputSchema, Map<String, Object> outputSchema,
+                   List<Map<String, Object>> parameters, Map<String, Object> example, Map<String, Object> metadata) {
         this.name = name;
         this.description = description;
         this.inputSchema = inputSchema;
         this.outputSchema = outputSchema;
         this.parameters = parameters;
         this.example = example;
+        this.metadata = metadata != null ? new LinkedHashMap<>(metadata) : new LinkedHashMap<>();
     }
 
     public String getName() {
@@ -74,6 +84,14 @@ public class McpTool {
         this.example = example;
     }
 
+    public Map<String, Object> getMetadata() {
+        return metadata;
+    }
+
+    public void setMetadata(Map<String, Object> metadata) {
+        this.metadata = metadata != null ? new LinkedHashMap<>(metadata) : new LinkedHashMap<>();
+    }
+
     @Override
     public String toString() {
         return "McpTool{" +
@@ -83,6 +101,7 @@ public class McpTool {
                 ", outputSchema=" + outputSchema +
                 ", parameters=" + parameters +
                 ", example=" + example +
+                ", metadata=" + metadata +
                 '}';
     }
 }

--- a/vscode-mcp-client-prompts.md
+++ b/vscode-mcp-client-prompts.md
@@ -25,6 +25,29 @@ Primero, asegúrate de que tu archivo `mcp.json` esté configurado correctamente
 
 El servidor Renovatio expone las siguientes herramientas MCP:
 
+### Metadata enriquecida disponible para prompts
+
+Cada herramienta publicada por el servidor incluye un bloque `metadata` que viaja en todas las respuestas MCP relevantes (`initialize.availableTools`, `tools/list.tools` y `tools/describe.tool`). Este bloque aporta información adicional que puedes aprovechar en tus prompts:
+
+- `displayName`: nombre amigable que puedes mostrar en UI o repetir en la conversación para confirmar la herramienta seleccionada.
+- `tags`: lista de etiquetas que describe el dominio, el lenguaje o el tipo de tarea que resuelve la herramienta. Útil para búsquedas o filtros rápidos.
+- Otros campos opcionales (`category`, `documentation`, etc.) pueden aparecer según el proveedor. Mantén el contenido textual del metadata accesible para enriquecer instrucciones y desambiguar herramientas similares.
+
+Ejemplo de fragmento devuelto por `tools/list`:
+
+```json
+{
+  "name": "java_analyze",
+  "description": "Analyze for java",
+  "metadata": {
+    "displayName": "Java Analyze",
+    "tags": ["java", "analysis"]
+  }
+}
+```
+
+Cuando redactes prompts, referencia el `displayName` para dar contexto al asistente (por ejemplo: *"utiliza la herramienta **Java Analyze** para..."*) y usa las `tags` como pistas para elegir la herramienta correcta en flujos automáticos.
+
 ### 🔍 Análisis de Código Java
 - **java_analyze**: Analiza estructura y extrae información de código Java
 - **java_metrics**: Calcula métricas de calidad y complejidad para código Java


### PR DESCRIPTION
## Summary
- add a metadata map to `McpTool`, wiring constructors, accessors and `toString`
- propagate metadata through `McpToolAdapter`, preferring metadata-supplied parameters/examples and round-tripping into `BasicTool`
- assert metadata delivery in MCP protocol tests and document how prompts can leverage the new fields

## Testing
- `mvn -pl renovatio-mcp-server -am test` *(fails: Maven cannot reach central repository from CI environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d043e0bf48832ea5fd6a4aff083445