### PR TITLE
Normalize MCP tool separators and expose recipe identifiers

### DIFF
--- a/renovatio-core/src/main/java/org/shark/renovatio/core/service/LanguageProviderRegistry.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/service/LanguageProviderRegistry.java
@@ -116,7 +116,31 @@ public class LanguageProviderRegistry {
             }
 
             String language = toolName.substring(0, separator);
-            String capability = toolName.substring(separator + 1);
+            String capabilitySection = toolName.substring(separator + 1);
+
+            String capability = capabilitySection;
+            String recipeId = null;
+
+            int dotInCapability = capabilitySection.indexOf('.');
+            int underscoreInCapability = capabilitySection.indexOf('_');
+            int recipeSeparator = -1;
+
+            if (dotInCapability >= 0 && underscoreInCapability >= 0) {
+                recipeSeparator = Math.min(dotInCapability, underscoreInCapability);
+            } else if (dotInCapability >= 0) {
+                recipeSeparator = dotInCapability;
+            } else if (underscoreInCapability >= 0) {
+                recipeSeparator = underscoreInCapability;
+            }
+
+            if (recipeSeparator > 0) {
+                capability = capabilitySection.substring(0, recipeSeparator);
+                recipeId = capabilitySection.substring(recipeSeparator + 1);
+                if (!recipeId.isEmpty()) {
+                    arguments.putIfAbsent("recipeId", recipeId);
+                }
+            }
+
             String capabilityKey = capability.toLowerCase();
 
             LanguageProvider provider = providers.get(language);

--- a/renovatio-core/src/test/java/org/shark/renovatio/core/service/LanguageProviderRegistryTest.java
+++ b/renovatio-core/src/test/java/org/shark/renovatio/core/service/LanguageProviderRegistryTest.java
@@ -1,0 +1,66 @@
+package org.shark.renovatio.core.service;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.shared.domain.ApplyResult;
+import org.shark.renovatio.shared.spi.LanguageProvider;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+class LanguageProviderRegistryTest {
+
+    @Test
+    void routeToolCallExtractsRecipeIdForApplyTools() {
+        LanguageProviderRegistry registry = new LanguageProviderRegistry();
+
+        LanguageProvider provider = mock(LanguageProvider.class);
+        when(provider.language()).thenReturn("java");
+        when(provider.capabilities()).thenReturn(Set.of(LanguageProvider.Capabilities.APPLY));
+        when(provider.apply(any(), anyBoolean(), any())).thenReturn(new ApplyResult(true, "ok"));
+
+        registry.registerProvider(provider);
+
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("workspacePath", "/tmp/workspace");
+
+        Map<String, Object> result = registry.routeToolCall(
+                "java.apply.org_openrewrite.migrate_to_java17",
+                arguments
+        );
+
+        assertNotNull(result, "Route result should never be null");
+        assertEquals("org_openrewrite.migrate_to_java17", arguments.get("recipeId"));
+
+        verify(provider).apply(any(), eq(true), any());
+    }
+
+    @Test
+    void routeToolCallSupportsUnderscoreRecipeSeparator() {
+        LanguageProviderRegistry registry = new LanguageProviderRegistry();
+
+        LanguageProvider provider = mock(LanguageProvider.class);
+        when(provider.language()).thenReturn("java");
+        when(provider.capabilities()).thenReturn(Set.of(LanguageProvider.Capabilities.APPLY));
+        when(provider.apply(any(), anyBoolean(), any())).thenReturn(new ApplyResult(true, "ok"));
+
+        registry.registerProvider(provider);
+
+        Map<String, Object> arguments = new HashMap<>();
+        arguments.put("workspacePath", "/tmp/workspace");
+
+        registry.routeToolCall("java.apply_org_openrewrite", arguments);
+
+        assertEquals("org_openrewrite", arguments.get("recipeId"));
+        verify(provider).apply(any(), eq(true), any());
+    }
+}

--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpProtocolService.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpProtocolService.java
@@ -157,14 +157,17 @@ public class McpProtocolService {
         if (name == null) {
             return null;
         }
-        if (name.contains("_")) {
+        int dotIndex = name.indexOf('.');
+        if (dotIndex < 0) {
             return name;
         }
-        int idx = name.indexOf('.');
-        if (idx < 0) {
+
+        int underscoreIndex = name.indexOf('_');
+        if (underscoreIndex >= 0 && underscoreIndex < dotIndex) {
             return name;
         }
-        return name.substring(0, idx) + '_' + name.substring(idx + 1);
+
+        return name.substring(0, dotIndex) + '_' + name.substring(dotIndex + 1);
     }
 
     /**

--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpToolAdapter.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpToolAdapter.java
@@ -27,8 +27,14 @@ public class McpToolAdapter {
 
         String originalToolName = tool.getName();
         String mcpToolName = originalToolName;
-        if (mcpToolName != null && !mcpToolName.contains("_") && mcpToolName.contains(".")) {
-            mcpToolName = mcpToolName.replace('.', '_');
+        if (mcpToolName != null) {
+            int dotIndex = mcpToolName.indexOf('.');
+            if (dotIndex > 0) {
+                int underscoreIndex = mcpToolName.indexOf('_');
+                if (underscoreIndex < 0 || dotIndex < underscoreIndex) {
+                    mcpToolName = mcpToolName.substring(0, dotIndex) + '_' + mcpToolName.substring(dotIndex + 1);
+                }
+            }
         }
 
         mcpTool.setName(mcpToolName);

--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpToolingService.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpToolingService.java
@@ -780,7 +780,7 @@ public class McpToolingService {
             return toolName;
         }
         String language = toolName.substring(0, idx);
-        String remainder = toolName.substring(idx + 1).replace('_', '.');
+        String remainder = toolName.substring(idx + 1);
         return language + '.' + remainder;
     }
 
@@ -793,7 +793,7 @@ public class McpToolingService {
             return toolName;
         }
         String language = toolName.substring(0, idx);
-        String remainder = toolName.substring(idx + 1).replace('_', '.');
+        String remainder = toolName.substring(idx + 1);
         return language + '.' + remainder;
     }
 }


### PR DESCRIPTION
## Summary
- ensure MCP tool name normalization only rewrites the language-capability separator
- parse recipe identifiers during routing so provider arguments include `recipeId`
- add tests that exercise apply calls with dotted and underscored recipe separators

## Testing
- `mvn -pl renovatio-core,renovatio-mcp-server test` *(fails: network is unreachable while downloading org.springframework.boot:spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68d04890dfd0832ea16dfde849189a6c