### PR TITLE
Normalize MCP tool names and preserve recipe metadata

### DIFF
--- a/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpProtocolService.java
+++ b/renovatio-mcp-server/src/main/java/org/shark/renovatio/mcp/server/service/McpProtocolService.java
@@ -5,6 +5,7 @@ import org.springframework.stereotype.Service;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
@@ -159,15 +160,16 @@ public class McpProtocolService {
         }
         int dotIndex = name.indexOf('.');
         if (dotIndex < 0) {
-            return name;
+            return name != null ? name.toLowerCase(Locale.ROOT) : null;
         }
 
         int underscoreIndex = name.indexOf('_');
         if (underscoreIndex >= 0 && underscoreIndex < dotIndex) {
-            return name;
+            return name.toLowerCase(Locale.ROOT);
         }
 
-        return name.substring(0, dotIndex) + '_' + name.substring(dotIndex + 1);
+        String normalized = name.substring(0, dotIndex) + '_' + name.substring(dotIndex + 1);
+        return normalized.toLowerCase(Locale.ROOT);
     }
 
     /**

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolProvider.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolProvider.java
@@ -150,7 +150,7 @@ public class CobolProvider extends BaseLanguageProvider {
 
         // Analyze tool
         BasicTool analyzeTool = new BasicTool(
-            "cobol_analyze",
+            "cobol.analyze",
             "Analyze COBOL source code",
             Map.of(
                 "type", "object",
@@ -173,11 +173,15 @@ public class CobolProvider extends BaseLanguageProvider {
             )
         ));
         analyzeTool.getMetadata().put("example", Map.of("workspacePath", "/path/to/cobol/workspace"));
+        analyzeTool.getMetadata().put("capability", "analyze");
+        analyzeTool.getMetadata().put("workflowPhase", "analysis");
+        analyzeTool.getMetadata().put("language", language());
+        analyzeTool.getMetadata().put("displayName", "Analyze COBOL code");
         tools.add(analyzeTool);
 
         // Metrics tool
         BasicTool metricsTool = new BasicTool(
-            "cobol_metrics",
+            "cobol.metrics",
             "Calculate COBOL code metrics",
             Map.of(
                 "type", "object",
@@ -200,11 +204,15 @@ public class CobolProvider extends BaseLanguageProvider {
             )
         ));
         metricsTool.getMetadata().put("example", Map.of("workspacePath", "/path/to/cobol/workspace"));
+        metricsTool.getMetadata().put("capability", "metrics");
+        metricsTool.getMetadata().put("workflowPhase", "baseline");
+        metricsTool.getMetadata().put("language", language());
+        metricsTool.getMetadata().put("displayName", "Collect COBOL metrics");
         tools.add(metricsTool);
 
         // Diff tool
         BasicTool diffTool = new BasicTool(
-            "cobol_diff",
+            "cobol.diff",
             "Generate semantic diff for COBOL code",
             Map.of(
                 "type", "object",
@@ -237,11 +245,15 @@ public class CobolProvider extends BaseLanguageProvider {
             )
         ));
         diffTool.getMetadata().put("example", Map.of("runId", "run-123", "workspacePath", "/path/to/cobol/workspace"));
+        diffTool.getMetadata().put("capability", "diff");
+        diffTool.getMetadata().put("workflowPhase", "review");
+        diffTool.getMetadata().put("language", language());
+        diffTool.getMetadata().put("displayName", "Review COBOL changes");
         tools.add(diffTool);
 
         // Generate stubs tool
         BasicTool stubsTool = new BasicTool(
-            "cobol_generateStubs",
+            "cobol.stubs_generate",
             "Generate Java stubs/adapters for COBOL interfaces",
             Map.of(
                 "type", "object",
@@ -274,6 +286,10 @@ public class CobolProvider extends BaseLanguageProvider {
             )
         ));
         stubsTool.getMetadata().put("example", Map.of("workspacePath", "/path/to/cobol/workspace", "targetLanguage", "java"));
+        stubsTool.getMetadata().put("capability", "stubs");
+        stubsTool.getMetadata().put("workflowPhase", "refactor");
+        stubsTool.getMetadata().put("language", language());
+        stubsTool.getMetadata().put("displayName", "Generate COBOL interface stubs");
         tools.add(stubsTool);
 
         return tools;


### PR DESCRIPTION
## Summary
- refactor the language provider registry to keep all providers per language, persist tool to provider mappings, and enrich routed calls with recipe ids and NQL parameters so workflows can target the right capability
- expand registry unit tests to cover recipe id parsing and capability-based provider selection
- sanitize MCP tool names while propagating language, capability, and original identifiers in tool metadata for richer clients
- normalize Java and COBOL provider tool slugs and metadata to emit lowercase MCP-safe identifiers with workflow phase hints

## Testing
- `mvn -pl renovatio-core,renovatio-provider-java,renovatio-provider-cobol,renovatio-mcp-server test` *(fails: repository parent POM fetch blocked by offline Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68d03fd0d408832ebd725b7eb5f408c2