### PR TITLE
Fix Java provider compilation issues

### DIFF
--- a/renovatio-provider-java/pom.xml
+++ b/renovatio-provider-java/pom.xml
@@ -66,6 +66,13 @@
             <version>${openrewrite.version}</version>
         </dependency>
 
+        <!-- JGit for interacting with git repositories -->
+        <dependency>
+            <groupId>org.eclipse.jgit</groupId>
+            <artifactId>org.eclipse.jgit</artifactId>
+            <version>6.8.0.202311291450-r</version>
+        </dependency>
+
         <!-- Test dependencies -->
         <dependency>
             <groupId>org.springframework.boot</groupId>

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaLanguageProvider.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaLanguageProvider.java
@@ -253,13 +253,9 @@ public class JavaLanguageProvider extends BaseLanguageProvider {
             }
 
             org.openrewrite.ExecutionContext ctx = new org.openrewrite.InMemoryExecutionContext(Throwable::printStackTrace);
-            List<String> sources = new ArrayList<>(javaFiles.size());
-            for (Path p : javaFiles) {
-                sources.add(Files.readString(p));
-            }
 
             org.openrewrite.java.JavaParser parser = org.openrewrite.java.JavaParser.fromJavaVersion().build();
-            List<org.openrewrite.SourceFile> sourceFileList = parser.parse(ctx, sources.toArray(new String[0])).collect(Collectors.toList());
+            List<org.openrewrite.SourceFile> sourceFileList = parser.parse(ctx, javaFiles.toArray(Path[]::new));
             List<org.openrewrite.Result> results = executeRecipeWithCompatibility(recipe, ctx, sourceFileList);
 
             if (apply) {

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaProvider.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaProvider.java
@@ -685,6 +685,26 @@ public class JavaProvider extends BaseLanguageProvider {
         });
     }
 
+    private Map<String, Object> discoverOutputSchema() {
+        Map<String, Object> dependency = new LinkedHashMap<>();
+        dependency.put("type", "object");
+        dependency.put("properties", Map.of(
+            "groupId", Map.of("type", "string"),
+            "artifactId", Map.of("type", "string"),
+            "version", Map.of("type", "string")
+        ));
+
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("properties", Map.of(
+            "modules", Map.of("type", "array", "items", Map.of("type", "string")),
+            "dependencies", Map.of("type", "array", "items", dependency),
+            "files", Map.of("type", "array", "items", Map.of("type", "string")),
+            "message", Map.of("type", "string")
+        ));
+        return schema;
+    }
+
     private Map<String, Object> analyzeOutputSchema() {
         Map<String, Object> issue = new LinkedHashMap<>();
         issue.put("type", "object");


### PR DESCRIPTION
## Summary
- add JGit dependency and expose discover tool output schema for the Java provider
- adjust OpenRewrite recipe discovery to fetch option defaults via reflection for compatibility
- update Java language provider parsing to use path-based parsing compatible with current OpenRewrite API

## Testing
- mvn -pl renovatio-provider-java -am -DskipTests compile *(fails: requires downloading parent POM from Maven Central, which is blocked in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d097998f30832ebe5fac191c6273a9