### PR TITLE
fix: support OpenRewrite LargeSourceSet invocation

### DIFF
--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaLanguageProvider.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/JavaLanguageProvider.java
@@ -258,8 +258,8 @@ public class JavaLanguageProvider extends BaseLanguageProvider {
                 sources.add(Files.readString(p));
             }
             List<org.openrewrite.SourceFile> sourceFileList = parser.parse(ctx, sources.toArray(new String[0])).collect(Collectors.toList());
-            // Usar la API moderna de OpenRewrite directamente
-            List<org.openrewrite.Result> results = recipe.run(sourceFileList, ctx);
+            // Delegate to OpenRewriteRunner to support both legacy and modern APIs
+            List<org.openrewrite.Result> results = openRewriteRunner.runRecipe(recipe, ctx, sourceFileList);
 
             if (apply) {
                 for (org.openrewrite.Result r : results) {


### PR DESCRIPTION
## Summary
- make `OpenRewriteRunner` bridge both `Iterable` and `LargeSourceSet` recipe execution paths using reflection and proxy fallbacks
- reuse `OpenRewriteRunner` inside `JavaLanguageProvider` so recipe execution stays compatible with OpenRewrite 7.x and 8.x APIs

## Testing
- `mvn -pl renovatio-provider-java -DskipTests compile` *(fails: network is unreachable while resolving org.springframework.boot:spring-boot-starter-parent:pom:3.2.5)*

------
https://chatgpt.com/codex/tasks/task_e_68d1381baea8832eb09776511dd9aab8