### PR TITLE
Prevent unsafe OpenRewrite recipes from executing

### DIFF
--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/discovery/OpenRewriteRecipeDiscoveryService.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/discovery/OpenRewriteRecipeDiscoveryService.java
@@ -39,6 +39,58 @@ public class OpenRewriteRecipeDiscoveryService {
 
     private static final Logger LOGGER = LoggerFactory.getLogger(OpenRewriteRecipeDiscoveryService.class);
 
+    private static final Set<String> UNSAFE_RECIPES = Set.of(
+        "org.openrewrite.java.CreateEmptyJavaClass",
+        "org.openrewrite.yaml.CreateYamlFile",
+        "org.openrewrite.text.CreateTextFile",
+        "org.openrewrite.xml.CreateXmlFile",
+        "org.openrewrite.RenameFile",
+        "org.openrewrite.java.ChangePackage",
+        "org.openrewrite.java.ChangeType",
+        "org.openrewrite.java.ChangeFieldType",
+        "org.openrewrite.java.ChangeFieldName",
+        "org.openrewrite.java.ChangeMethodName",
+        "org.openrewrite.java.ChangeStaticFieldToMethod",
+        "org.openrewrite.java.AddImport",
+        "org.openrewrite.java.RemoveImport",
+        "org.openrewrite.java.ReplaceStringLiteral",
+        "org.openrewrite.java.search.FindMethods",
+        "org.openrewrite.java.search.FindFields",
+        "org.openrewrite.java.search.FindTypes",
+        "org.openrewrite.java.dependencies.AddDependency",
+        "org.openrewrite.java.dependencies.RemoveDependency",
+        "org.openrewrite.java.dependencies.ChangeDependency",
+        // Recipes that act as generic containers require explicit configuration.
+        "org.openrewrite.config.CompositeRecipe"
+    );
+
+    private static final Set<String> REQUIRED_OPTION_KEYWORDS = Set.of(
+        "packagename",
+        "classname",
+        "filepath",
+        "filename",
+        "path",
+        "methodname",
+        "fieldname",
+        "typename",
+        "oldname",
+        "newname",
+        "oldtype",
+        "newtype",
+        "groupid",
+        "artifactid",
+        "version",
+        "type",
+        "name",
+        "target",
+        "source",
+        // Recipes that compose other recipes almost always require explicit configuration
+        "recipe",
+        "recipelist",
+        "template",
+        "contents"
+    );
+
     private final Environment environment;
     private final Map<String, RecipeInfo> recipes;
     private final Map<String, List<String>> profiles;
@@ -75,8 +127,9 @@ public class OpenRewriteRecipeDiscoveryService {
         }
         List<String> filtered = recipeNames.stream()
             .filter(Objects::nonNull)
+            .map(String::trim)
             .filter(name -> !name.isBlank())
-            .filter(this::isRecipeSafeToExecute)
+            .filter(this::isRecipeSafe)
             .distinct()
             .collect(Collectors.toList());
         if (filtered.isEmpty()) {
@@ -217,7 +270,7 @@ public class OpenRewriteRecipeDiscoveryService {
         // For "all" profile, only include safe recipes
         List<String> allSafeRecipes = new ArrayList<>();
         for (String recipeName : recipes.keySet()) {
-            if (isRecipeSafeToExecute(recipeName)) {
+            if (isRecipeSafe(recipeName)) {
                 allSafeRecipes.add(recipeName);
             }
         }
@@ -233,7 +286,7 @@ public class OpenRewriteRecipeDiscoveryService {
         if (requiredTags == null || requiredTags.isEmpty()) {
             List<String> safeRecipes = new ArrayList<>();
             for (String recipeName : recipes.keySet()) {
-                if (isRecipeSafeToExecute(recipeName)) {
+                if (isRecipeSafe(recipeName)) {
                     safeRecipes.add(recipeName);
                 }
             }
@@ -242,7 +295,7 @@ public class OpenRewriteRecipeDiscoveryService {
         
         List<String> matches = new ArrayList<>();
         for (RecipeInfo info : recipes.values()) {
-            if (info.tags().containsAll(requiredTags) && isRecipeSafeToExecute(info.name())) {
+            if (info.tags().containsAll(requiredTags) && isRecipeSafe(info.name())) {
                 matches.add(info.name());
             }
         }
@@ -251,7 +304,7 @@ public class OpenRewriteRecipeDiscoveryService {
             // fall back to partial matches, but still apply safety filter
             for (RecipeInfo info : recipes.values()) {
                 for (String tag : requiredTags) {
-                    if (info.tags().contains(tag) && isRecipeSafeToExecute(info.name())) {
+                    if (info.tags().contains(tag) && isRecipeSafe(info.name())) {
                         matches.add(info.name());
                         break;
                     }
@@ -288,41 +341,16 @@ public class OpenRewriteRecipeDiscoveryService {
      * Check if a recipe is safe to execute without additional configuration.
      * Some recipes require specific parameters that may not be set and can cause NPE.
      */
-    private boolean isRecipeSafeToExecute(String recipeName) {
+    public boolean isRecipeSafe(String recipeName) {
         if (recipeName == null || recipeName.isBlank()) {
             return false;
         }
-        
-        // Filter out recipes that typically require specific configuration
-        // These recipes often fail with NPE when required parameters are not set
-        Set<String> problematicRecipes = Set.of(
-            "org.openrewrite.java.CreateEmptyJavaClass",
-            "org.openrewrite.yaml.CreateYamlFile", 
-            "org.openrewrite.text.CreateTextFile",
-            "org.openrewrite.xml.CreateXmlFile",
-            "org.openrewrite.RenameFile",
-            "org.openrewrite.java.ChangePackage",
-            "org.openrewrite.java.ChangeType",
-            "org.openrewrite.java.ChangeFieldType",
-            "org.openrewrite.java.ChangeFieldName",
-            "org.openrewrite.java.ChangeMethodName",
-            "org.openrewrite.java.ChangeStaticFieldToMethod",
-            "org.openrewrite.java.AddImport",
-            "org.openrewrite.java.RemoveImport",
-            "org.openrewrite.java.ReplaceStringLiteral",
-            "org.openrewrite.java.search.FindMethods",
-            "org.openrewrite.java.search.FindFields",
-            "org.openrewrite.java.search.FindTypes",
-            "org.openrewrite.java.dependencies.AddDependency",
-            "org.openrewrite.java.dependencies.RemoveDependency",
-            "org.openrewrite.java.dependencies.ChangeDependency"
-        );
-        
-        if (problematicRecipes.contains(recipeName)) {
+
+        if (UNSAFE_RECIPES.contains(recipeName)) {
             LOGGER.debug("Filtering out recipe {} - requires specific configuration", recipeName);
             return false;
         }
-        
+
         // Check for recipe patterns that typically require configuration
         if (recipeName.toLowerCase(Locale.ROOT).contains("create") && 
             (recipeName.contains("Class") || recipeName.contains("File"))) {
@@ -335,7 +363,7 @@ public class OpenRewriteRecipeDiscoveryService {
             LOGGER.debug("Filtering out recipe {} - change recipes typically require specific parameters", recipeName);
             return false;
         }
-        
+
         // Also filter recipes that are known to require parameters
         RecipeInfo info = recipes.get(recipeName);
         if (info != null && hasRequiredOptions(info)) {
@@ -362,35 +390,16 @@ public class OpenRewriteRecipeDiscoveryService {
             
             String optionName = option.name().toLowerCase(Locale.ROOT);
             // These are typically required parameters that cause NPE if null
-            if (optionName.contains("packagename") || 
-                optionName.contains("classname") ||
-                optionName.contains("filepath") ||
-                optionName.contains("filename") ||
-                optionName.contains("path") ||
-                optionName.contains("methodname") ||
-                optionName.contains("fieldname") ||
-                optionName.contains("typename") ||
-                optionName.contains("oldname") ||
-                optionName.contains("newname") ||
-                optionName.contains("oldtype") ||
-                optionName.contains("newtype") ||
-                optionName.contains("groupid") ||
-                optionName.contains("artifactid") ||
-                optionName.contains("version") ||
-                // Common OpenRewrite option patterns
-                optionName.equals("type") ||
-                optionName.equals("name") ||
-                optionName.equals("target") ||
-                optionName.equals("source")) {
-                
-                // Check if the option has a default value - if not, it's likely required
-                if (option.defaultValue() == null || 
-                    (option.defaultValue() instanceof String && ((String) option.defaultValue()).isEmpty())) {
+            if (REQUIRED_OPTION_KEYWORDS.stream().anyMatch(optionName::contains)) {
+                Object defaultValue = option.defaultValue();
+                if (defaultValue == null ||
+                    (defaultValue instanceof String str && str.isBlank()) ||
+                    (defaultValue instanceof Collection<?> collection && collection.isEmpty())) {
                     return true;
                 }
             }
         }
-        
+
         return false;
     }
 

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/execution/JavaRecipeExecutor.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/execution/JavaRecipeExecutor.java
@@ -81,11 +81,22 @@ public class JavaRecipeExecutor {
                     "No Java files found in workspace");
             }
 
-            List<String> recipeList = recipes != null ? recipes.stream()
+            List<String> requestedRecipes = recipes != null ? recipes.stream()
                 .filter(Objects::nonNull)
+                .map(String::trim)
                 .filter(name -> !name.isBlank())
-                .distinct()
                 .collect(Collectors.toList()) : List.of();
+
+            List<String> recipeList = requestedRecipes.stream()
+                .filter(name -> {
+                    if (discoveryService.isRecipeSafe(name)) {
+                        return true;
+                    }
+                    LOGGER.warn("Skipping recipe '{}' - requires specific configuration parameters that are not provided", name);
+                    return false;
+                })
+                .distinct()
+                .collect(Collectors.toList());
 
             ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
             List<SourceFile> sourceFiles = parseSources(javaFiles, ctx);

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/planner/JavaRefactorPlanner.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/planner/JavaRefactorPlanner.java
@@ -2,7 +2,6 @@ package org.shark.renovatio.provider.java.planner;
 
 import org.shark.renovatio.provider.java.discovery.OpenRewriteRecipeDiscoveryService;
 import org.shark.renovatio.provider.java.discovery.OpenRewriteRecipeDiscoveryService.RecipeInfo;
-import org.shark.renovatio.provider.java.discovery.OpenRewriteRecipeDiscoveryService.RecipeOption;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -15,7 +14,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -55,9 +53,13 @@ public class JavaRefactorPlanner {
         if (includeRecipes != null) {
             for (String recipe : includeRecipes) {
                 if (recipe != null && !recipe.isBlank()) {
+                    String trimmed = recipe.trim();
+                    if (trimmed.isEmpty()) {
+                        continue;
+                    }
                     // Apply safety filter to ensure we don't execute recipes that require specific configuration
-                    if (isRecipeSafeToExecute(recipe)) {
-                        selected.add(recipe);
+                    if (discoveryService.isRecipeSafe(trimmed)) {
+                        selected.add(trimmed);
                     } else {
                         LOGGER.warn("Skipping recipe '{}' - requires specific configuration parameters that are not provided", recipe);
                     }
@@ -142,113 +144,5 @@ public class JavaRefactorPlanner {
 
     private String generatePlanId() {
         return "java-plan-" + UUID.randomUUID();
-    }
-
-    /**
-     * Check if a recipe is safe to execute without additional configuration.
-     * Some recipes require specific parameters that may not be set and can cause NPE.
-     * This method duplicates the logic from OpenRewriteRecipeDiscoveryService to ensure
-     * consistent filtering.
-     */
-    private boolean isRecipeSafeToExecute(String recipeName) {
-        if (recipeName == null || recipeName.isBlank()) {
-            return false;
-        }
-        
-        // Filter out recipes that typically require specific configuration
-        // These recipes often fail with NPE when required parameters are not set
-        Set<String> problematicRecipes = Set.of(
-            "org.openrewrite.java.CreateEmptyJavaClass",
-            "org.openrewrite.yaml.CreateYamlFile", 
-            "org.openrewrite.text.CreateTextFile",
-            "org.openrewrite.xml.CreateXmlFile",
-            "org.openrewrite.RenameFile",
-            "org.openrewrite.java.ChangePackage",
-            "org.openrewrite.java.ChangeType",
-            "org.openrewrite.java.ChangeFieldType",
-            "org.openrewrite.java.ChangeFieldName",
-            "org.openrewrite.java.ChangeMethodName",
-            "org.openrewrite.java.ChangeStaticFieldToMethod",
-            "org.openrewrite.java.AddImport",
-            "org.openrewrite.java.RemoveImport",
-            "org.openrewrite.java.ReplaceStringLiteral",
-            "org.openrewrite.java.search.FindMethods",
-            "org.openrewrite.java.search.FindFields",
-            "org.openrewrite.java.search.FindTypes",
-            "org.openrewrite.java.dependencies.AddDependency",
-            "org.openrewrite.java.dependencies.RemoveDependency",
-            "org.openrewrite.java.dependencies.ChangeDependency"
-        );
-        
-        if (problematicRecipes.contains(recipeName)) {
-            return false;
-        }
-        
-        // Check for recipe patterns that typically require configuration
-        if (recipeName.toLowerCase(Locale.ROOT).contains("create") && 
-            (recipeName.contains("Class") || recipeName.contains("File"))) {
-            return false;
-        }
-        
-        if (recipeName.toLowerCase(Locale.ROOT).contains("change") &&
-            (recipeName.contains("Type") || recipeName.contains("Method") || recipeName.contains("Field"))) {
-            return false;
-        }
-        
-        // Also filter recipes that are known to require parameters
-        Optional<RecipeInfo> recipeInfo = discoveryService.describeRecipe(recipeName);
-        if (recipeInfo.isPresent() && hasRequiredOptions(recipeInfo.get())) {
-            return false;
-        }
-        
-        return true;
-    }
-    
-    /**
-     * Check if a recipe has options that are typically required for execution.
-     */
-    private boolean hasRequiredOptions(RecipeInfo info) {
-        if (info.options() == null || info.options().isEmpty()) {
-            return false;
-        }
-        
-        // Check for common parameter patterns that usually indicate required configuration
-        for (RecipeOption option : info.options()) {
-            if (option.name() == null) {
-                continue;
-            }
-            
-            String optionName = option.name().toLowerCase(Locale.ROOT);
-            // These are typically required parameters that cause NPE if null
-            if (optionName.contains("packagename") || 
-                optionName.contains("classname") ||
-                optionName.contains("filepath") ||
-                optionName.contains("filename") ||
-                optionName.contains("path") ||
-                optionName.contains("methodname") ||
-                optionName.contains("fieldname") ||
-                optionName.contains("typename") ||
-                optionName.contains("oldname") ||
-                optionName.contains("newname") ||
-                optionName.contains("oldtype") ||
-                optionName.contains("newtype") ||
-                optionName.contains("groupid") ||
-                optionName.contains("artifactid") ||
-                optionName.contains("version") ||
-                // Common OpenRewrite option patterns
-                optionName.equals("type") ||
-                optionName.equals("name") ||
-                optionName.equals("target") ||
-                optionName.equals("source")) {
-                
-                // Check if the option has a default value - if not, it's likely required
-                if (option.defaultValue() == null || 
-                    (option.defaultValue() instanceof String && ((String) option.defaultValue()).isEmpty())) {
-                    return true;
-                }
-            }
-        }
-        
-        return false;
     }
 }

--- a/renovatio-provider-java/src/test/java/org/shark/renovatio/provider/java/discovery/OpenRewriteRecipeDiscoveryServiceSafetyTest.java
+++ b/renovatio-provider-java/src/test/java/org/shark/renovatio/provider/java/discovery/OpenRewriteRecipeDiscoveryServiceSafetyTest.java
@@ -1,0 +1,42 @@
+package org.shark.renovatio.provider.java.discovery;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenRewriteRecipeDiscoveryServiceSafetyTest {
+
+    private static final OpenRewriteRecipeDiscoveryService DISCOVERY_SERVICE = new OpenRewriteRecipeDiscoveryService();
+
+    @Test
+    void compositeRecipeRequiresConfiguration() {
+        assertFalse(DISCOVERY_SERVICE.isRecipeSafe("org.openrewrite.config.CompositeRecipe"),
+            "CompositeRecipe should be treated as unsafe without explicit configuration");
+    }
+
+    @Test
+    void createEmptyJavaClassRequiresConfiguration() {
+        assertFalse(DISCOVERY_SERVICE.isRecipeSafe("org.openrewrite.java.CreateEmptyJavaClass"),
+            "CreateEmptyJavaClass should be treated as unsafe when packageName is not provided");
+    }
+
+    @Test
+    void autoFormatRecipeIsSafe() {
+        assertTrue(DISCOVERY_SERVICE.isRecipeSafe("org.openrewrite.java.format.AutoFormat"),
+            "AutoFormat is expected to be safe to run without additional configuration");
+    }
+
+    @Test
+    void curatedProfilesExcludeUnsafeRecipes() {
+        List<String> qualityProfile = DISCOVERY_SERVICE.profilesToRecipes().get("quality");
+        assertNotNull(qualityProfile, "Quality profile should be available");
+        assertFalse(qualityProfile.contains("org.openrewrite.config.CompositeRecipe"),
+            "Quality profile should not include recipes that require additional configuration");
+        assertFalse(qualityProfile.contains("org.openrewrite.java.CreateEmptyJavaClass"),
+            "Quality profile should exclude CreateEmptyJavaClass to avoid NPEs");
+    }
+}


### PR DESCRIPTION
## Summary
- centralize OpenRewrite recipe safety checks and expand the unsafe recipe list to cover composite recipes
- reuse the safety guardrails in the planner and executor so user-provided recipe lists are filtered consistently
- add a regression test that asserts unsafe recipes are excluded from curated profiles

## Testing
- `mvn -pl renovatio-provider-java test` *(fails: unable to reach Maven Central to resolve the Spring Boot parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68d34a1ff65c832eaccb8b49b3074fe9