### PR TITLE
Handle scoped CreateEmptyJavaClass recipes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,6 +58,8 @@ dist/
 
 # Application specific
 renovatio
+!*/src/**/renovatio
+!*/src/**/renovatio/**
 *.class
 
 # Test coverage

--- a/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/OpenRewriteRunner.java
+++ b/renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/OpenRewriteRunner.java
@@ -190,10 +190,16 @@ public class OpenRewriteRunner {
     }
 
     private boolean matchesRecipe(Recipe recipe, String recipeName, String targetName) {
-        if (targetName.equals(recipe.getClass().getName())) {
+        String className = recipe.getClass().getName();
+        if (targetName.equals(className) || className.startsWith(targetName + "$")) {
             return true;
         }
-        return recipeName != null && targetName.equals(recipeName);
+
+        if (recipeName != null) {
+            return targetName.equals(recipeName) || recipeName.startsWith(targetName + "$");
+        }
+
+        return false;
     }
 
     /**

--- a/renovatio-provider-java/src/test/java/org/shark/renovatio/provider/java/OpenRewriteRunnerSafetyTest.java
+++ b/renovatio-provider-java/src/test/java/org/shark/renovatio/provider/java/OpenRewriteRunnerSafetyTest.java
@@ -1,0 +1,49 @@
+package org.shark.renovatio.provider.java;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Recipe;
+import org.openrewrite.TreeVisitor;
+import org.openrewrite.tree.Tree;
+
+import java.lang.reflect.Method;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class OpenRewriteRunnerSafetyTest {
+
+    @Test
+    void detectsMissingParametersForScopedCreateEmptyJavaClass() throws Exception {
+        OpenRewriteRunner runner = new OpenRewriteRunner();
+        Method method = OpenRewriteRunner.class.getDeclaredMethod("isRecipeMissingRequiredParameters", Recipe.class);
+        method.setAccessible(true);
+
+        Recipe scopedRecipe = new ScopedCreateEmptyJavaClassStub();
+        boolean missingParameters = (boolean) method.invoke(runner, scopedRecipe);
+
+        assertTrue(missingParameters, "Scoped CreateEmptyJavaClass instances should be flagged as missing required parameters");
+    }
+
+    private static final class ScopedCreateEmptyJavaClassStub extends Recipe {
+
+        @Override
+        public String getDisplayName() {
+            return "Scoped CreateEmptyJavaClass Stub";
+        }
+
+        @Override
+        public String getDescription() {
+            return "Stub used to verify parameter safety checks";
+        }
+
+        @Override
+        public String getName() {
+            return "org.openrewrite.java.CreateEmptyJavaClass$Scoped";
+        }
+
+        @Override
+        protected TreeVisitor<?, ExecutionContext> getVisitor() {
+            return new TreeVisitor<Tree, ExecutionContext>() { };
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- update the OpenRewrite runner so parameter checks also apply to scoped CreateEmptyJavaClass recipes
- add a regression test that verifies scoped recipes are treated as missing required parameters
- adjust the gitignore rules so Java package directories named `renovatio` are not excluded from version control

## Testing
- mvn -pl renovatio-provider-java -am test *(fails: cannot resolve parent POM org.springframework.boot:spring-boot-starter-parent:3.2.5 because Maven Central is unreachable in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68d3ddcda7d0832e8e85f70144a9ceea