### PR TITLE
docs: document shared and core modules

### DIFF
--- a/renovatio-core/src/main/java/module-info.java
+++ b/renovatio-core/src/main/java/module-info.java
@@ -1,0 +1,14 @@
+open module org.shark.renovatio.core {
+    requires transitive org.shark.renovatio.shared;
+    requires spring.context;
+    requires spring.web;
+    requires org.mapstruct;
+    requires jakarta.annotation;
+    requires org.apache.pdfbox;
+
+    exports org.shark.renovatio.core.dto;
+    exports org.shark.renovatio.core.entity;
+    exports org.shark.renovatio.core.infrastructure;
+    exports org.shark.renovatio.core.mapper;
+    exports org.shark.renovatio.core.service;
+}

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/dto/package-info.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/dto/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Data transfer objects (DTOs) exposed by the core module when interacting with clients.
+ * <p>
+ * DTOs maintain serialization friendly representations of domain concepts to keep the
+ * service layer isolated from persistence specifics.
+ */
+package org.shark.renovatio.core.dto;

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/entity/package-info.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/entity/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Persistence oriented entities used by Renovatio's core services.
+ * <p>
+ * Entities represent data structures that may be mapped to external storage while remaining
+ * independent from framework annotations to support multiple persistence strategies.
+ */
+package org.shark.renovatio.core.entity;

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/infrastructure/package-info.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/infrastructure/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Infrastructure components that adapt core services to external interfaces such as REST APIs.
+ * <p>
+ * Controllers, configuration and transport specific adapters live here to keep the service
+ * layer framework agnostic.
+ */
+package org.shark.renovatio.core.infrastructure;

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/mapper/package-info.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/mapper/package-info.java
@@ -1,0 +1,6 @@
+/**
+ * MapStruct based mappers bridging between persistent entities and DTOs.
+ * <p>
+ * Centralising mapper definitions ensures consistent conversion logic and eases testing.
+ */
+package org.shark.renovatio.core.mapper;

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/package-info.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Core Renovatio services orchestrating provider discovery, reporting and REST exposure.
+ * <p>
+ * The package acts as the central application layer and groups supporting sub-packages that
+ * encapsulate DTOs, persistence entities, mappers and Spring managed services.
+ */
+package org.shark.renovatio.core;

--- a/renovatio-core/src/main/java/org/shark/renovatio/core/service/package-info.java
+++ b/renovatio-core/src/main/java/org/shark/renovatio/core/service/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Core application services responsible for orchestrating Renovatio workflows.
+ * <p>
+ * Services coordinate provider registries, reporting pipelines and integration with
+ * infrastructure adapters while keeping business logic cohesive.
+ */
+package org.shark.renovatio.core.service;

--- a/renovatio-shared/src/main/java/module-info.java
+++ b/renovatio-shared/src/main/java/module-info.java
@@ -1,0 +1,10 @@
+open module org.shark.renovatio.shared {
+    requires transitive com.fasterxml.jackson.annotation;
+    requires transitive spring.context;
+    requires transitive org.antlr.antlr4.runtime;
+
+    exports org.shark.renovatio.shared.domain;
+    exports org.shark.renovatio.shared.nql;
+    exports org.shark.renovatio.shared.spi;
+    exports org.shark.renovatio.shared.util;
+}

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/domain/package-info.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/domain/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Domain-centric data structures and value objects shared across providers and services.
+ * <p>
+ * These DTOs capture the canonical representation of analysis results, migration plans and
+ * supporting metrics required to coordinate refactoring workflows.
+ */
+package org.shark.renovatio.shared.domain;

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/nql/package-info.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/nql/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Components related to the Renovatio Native Query Language (NQL) grammar and parser.
+ * <p>
+ * Parser services, generated grammar classes and compile results live here so that providers
+ * can interpret NQL expressions consistently.
+ */
+package org.shark.renovatio.shared.nql;

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/package-info.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/package-info.java
@@ -1,0 +1,8 @@
+/**
+ * Core shared abstractions and infrastructure that are reused across Renovatio modules.
+ * <p>
+ * This package exposes lightweight building blocks such as value objects, enums and
+ * cross-cutting services that are safe to depend on from providers and higher level modules.
+ * Keeping the documentation co-located helps preserve a clear architectural contract.
+ */
+package org.shark.renovatio.shared;

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/spi/package-info.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/spi/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Service Provider Interfaces (SPI) that describe the contract a language provider must implement.
+ * <p>
+ * Implementations in provider modules plug into these abstractions to contribute new tooling
+ * capabilities without leaking implementation details.
+ */
+package org.shark.renovatio.shared.spi;

--- a/renovatio-shared/src/main/java/org/shark/renovatio/shared/util/package-info.java
+++ b/renovatio-shared/src/main/java/org/shark/renovatio/shared/util/package-info.java
@@ -1,0 +1,7 @@
+/**
+ * Shared utility helpers that provide non-domain specific behaviour for Renovatio modules.
+ * <p>
+ * Utilities remain intentionally small and focused to avoid growing cross-module coupling while
+ * still offering reusable building blocks.
+ */
+package org.shark.renovatio.shared.util;


### PR DESCRIPTION
## Summary
- add JPMS descriptors for the shared and core modules to capture module dependencies
- document the intent of shared and core packages via package-info.java files to improve discoverability

## Testing
- mvn -pl renovatio-shared -am test *(fails: 403 Forbidden when downloading spring-boot-starter-parent)*

------
https://chatgpt.com/codex/tasks/task_e_68e183456574832e81d2c5116f9aee57