### PR TITLE
Implement COBOL IR pipeline and COBOL-to-Java recipes

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -74,6 +74,21 @@ both standalone usage and MCP client integration.
 - COBOL parsing and analysis
 - COBOL-to-Java migration
 - Code generation capabilities
+- Semantic translation pipeline powered by the COBOL IR and OpenRewrite recipes
+
+### Supporting Modules
+
+#### renovatio-cobol-ir
+
+- Normalised intermediate representation for COBOL programs (data division, paragraphs, control flow)
+- Lightweight parser capable of extracting statements (`MOVE`, `COMPUTE`, `IF`, `PERFORM`, embedded SQL)
+- Execution context metadata used by translators
+
+#### cobol-openrewrite-recipes
+
+- Custom OpenRewrite recipes that consume the COBOL IR
+- `PopulateCobolProcessRecipe` replaces service `process` method TODOs with Java statements derived from COBOL paragraphs
+- Recipes enforce Java 17 compatibility via `HasMinimumJavaVersion`
 
 ## Design Principles
 

--- a/PLAN-TRADUCCION-COBOL-JAVA.md
+++ b/PLAN-TRADUCCION-COBOL-JAVA.md
@@ -1,0 +1,97 @@
+# Plan para implementar la traducción real de COBOL a Java
+
+## 1. Estado actual del generador COBOL → Java
+
+- Los servicios generados a partir de plantillas incluyen solo comentarios `TODO` en los puntos donde debería migrarse la lógica de negocio (`TemplateCodeGenerationService`).【F:renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/TemplateCodeGenerationService.java†L41-L80】
+- Las clases construidas con JavaPoet crean métodos `process` y `validate` sin implementar la semántica original del programa COBOL.【F:renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/JavaGenerationService.java†L200-L250】
+- El adaptador de programas COBOL mantiene excepciones `UnsupportedOperationException`, lo que evidencia la falta de integración con la lógica real migrada.【F:renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/CobolProvider.java†L381-L407】
+
+## 2. Objetivo de la mejora
+
+Construir una canalización que transforme la **semántica** de los párrafos COBOL (procedures, condiciones `IF/EVALUATE`, sentencias `PERFORM`, accesos a archivos/DB2, etc.) en código Java funcional, generando servicios Spring con reglas de negocio reales y pruebas automatizadas.
+
+## 3. Componentes técnicos necesarios
+
+### 3.1. Extracción semántica del COBOL
+
+1. **Parser enriquecido**: utilizar `ProLeap` (ya presente como dependencia) con listeners propios para extraer:
+   - División `DATA`: tipos, estructuras, niveles, `PIC`, `REDEFINES`, `OCCURS`.
+   - División `PROCEDURE`: párrafos, secciones, sentencias, flujo de control.
+2. **Árbol intermedio (IR)**: definir un modelo `CobolIntermediateModel` que normalice:
+   - Nodos de control (`IfNode`, `EvaluateNode`, `PerformNode`).
+   - Operaciones aritméticas y de movimientos (`MoveNode`, `ComputeNode`).
+   - Interacciones externas (`CallNode`, `Db2Node`, `FileNode`).
+3. **Análisis de flujo**: construir un grafo de flujo de control (CFG) para resolver `PERFORM THRU`, `GO TO`, `EXIT`, garantizando orden de ejecución para la traducción.
+
+### 3.2. Motor de traducción alineado con OpenRewrite
+
+1. **Recipes OpenRewrite personalizadas**: definir un módulo `cobol-openrewrite-recipes` donde cada nodo del IR se materialice como una `Recipe` de OpenRewrite que parte del stub generado y lo enriquece con la lógica real (por ejemplo `CobolPerformRecipe`, `CobolEvaluateRecipe`). Estas recetas deberán construir o modificar `J.MethodDeclaration`, `J.If`, `J.Switch`, etc., para garantizar un AST Java válido.
+2. **Infraestructura compartida**: reutilizar directamente `OpenRewriteRunner` y el ciclo de ejecución existente (`JavaRecipeExecutor`) para aplicar las nuevas recetas a los servicios generados, asegurando la misma interfaz MCP (`preview/apply`, métricas, validaciones de seguridad).【F:renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/OpenRewriteRunner.java†L12-L132】【F:renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/execution/JavaRecipeExecutor.java†L23-L169】
+3. **Descubrimiento y composición**: registrar las recetas COBOL en `OpenRewriteRecipeDiscoveryService` para exponerlas como herramientas MCP al igual que las de Java, aprovechando la activación dinámica, validaciones y marcado de recetas inseguras.【F:renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/discovery/OpenRewriteRecipeDiscoveryService.java†L22-L158】
+4. **Conversión de tipos y estado**: mantener una tabla `PIC` → tipos Java y un contexto de ejecución (`CobolExecutionContext`) que puedan inyectarse a las recetas para generar atributos, DTOs y parámetros adecuados.
+5. **Soporte DB2/archivos**:
+   - Incluir recetas específicas para construir repositorios Spring Data/JDBC a partir de metadata COBOL.
+   - Generar adaptadores de I/O mediante recetas que creen componentes Spring (`@Repository`, `@Component`) con la configuración necesaria.
+
+### 3.3. Integración con Spring y la capa de servicios
+
+1. Generar **servicios transaccionales** (`@Service`, `@Transactional`) que invoquen los bloques traducidos.
+2. Crear **componentes reutilizables** para:
+   - Conversión de copybooks a DTO (`CopybookMapper` con MapStruct).
+   - Gestión de errores (`CobolRuntimeException`, `CobolConditionHandler`).
+3. Implementar **adaptadores** que repliquen las llamadas externas: CICS, MQ, web services, etc. Bibliotecas de referencia:
+   - `LegStar` para llamadas CICS/IMS.
+   - `Jackson`/`MapStruct` para serialización.
+   - `Spring Integration` para colas/mensajería.
+
+### 3.4. Configuración de la versión objetivo de Java
+
+1. **Versión unificada**: establecer Java 17 como target para los servicios traducidos, alineado con el stack actual del proyecto.
+2. **OpenRewrite HasMinimumJavaVersion**: actualizar la configuración YAML para las nuevas recetas COBOL e incluir explícitamente el target (`version: '17'`) siguiendo el patrón ya usado por el proveedor Java.【F:renovatio-provider-java/rewrite.yml†L1-L7】
+3. **Generación de código**: propagar la versión destino al generador (JavaPoet, plantillas Freemarker y validaciones) para asegurar compatibilidad con records, `var` y APIs de Java 17 cuando aplique.
+
+### 3.5. Generación de pruebas automatizadas
+
+1. Usar el IR para producir casos de prueba JUnit:
+   - Inputs/outputs derivados de las reglas `MOVE`, `IF`, `EVALUATE`.
+   - Fixtures generados a partir de `COPY` y ejemplos de datos.
+2. Validar equivalencia ejecutando el programa COBOL original (si es posible) vía `GnuCOBOL` o servicios mockeados y comparando resultados.
+
+## 4. Flujo propuesto
+
+1. **Parsing** → `CobolParserService` produce IR.
+2. **Normalización** → Resuelve `PERFORM` y estructura el CFG.
+3. **Traducción** → Módulo de reglas genera AST Java (`JavaPoet`/`OpenRewrite`).
+4. **Ensamblado** → Plantillas Freemarker + clases generadas integran DTO, servicios, adaptadores.
+5. **Testing** → Se crean pruebas unitarias/integración y se ejecutan en Maven.
+
+## 5. Roadmap incremental
+
+| Fase | Entregables clave |
+|------|-------------------|
+| Fase 1 | Definición del IR, listeners ProLeap, primeras recetas OpenRewrite (`MOVE`, `IF`, `PERFORM`) ejecutadas con el `OpenRewriteRunner`. |
+| Fase 2 | Soporte para `EVALUATE`, `STRING/UNSTRING`, aritmética completa, generación de DTOs enriquecidos y registro en `OpenRewriteRecipeDiscoveryService`. |
+| Fase 3 | Integración DB2/archivos, recetas para repositorios y servicios Spring transaccionales. |
+| Fase 4 | Traducción de llamadas externas (CICS/MQ), adaptadores configurables, pruebas automáticas generadas. |
+| Fase 5 | Optimización y validación (comparación con ejecución COBOL, perfilado de rendimiento). |
+
+## 6. Herramientas y librerías recomendadas
+
+- **ProLeap** o **Koopa**: parsing COBOL y obtención de AST detallado.
+- **OpenRewrite** + **JavaPoet**: generación y refactorización de código Java.
+- **MapStruct**: mapeo automático de DTO ↔ estructuras COBOL.
+- **jOOQ** / **Spring Data JDBC**: traducción de sentencias DB2 a repositorios Java.
+- **LegStar** / **Spring Integration**: integración con CICS, MQ y servicios externos.
+- **GnuCOBOL** (en pipelines CI) para validar resultados ejecutando el programa original.
+- **ANTLR** (opcional) para reglas específicas cuando ProLeap no cubra ciertas extensiones.
+
+## 7. Próximos pasos inmediatos
+
+1. Crear el módulo `renovatio-cobol-ir` con el modelo intermedio y pruebas sobre un COBOL de ejemplo.
+2. Construir el módulo `cobol-openrewrite-recipes` reutilizando `OpenRewriteRunner` para validar las primeras recetas (`MOVE`, `COMPUTE`, `IF`, `PERFORM`).
+3. Registrar las recetas en `OpenRewriteRecipeDiscoveryService` y exponer herramientas MCP (`cobol.<recipeId>`) con la misma interfaz que `java.apply`/`java.analyze`.
+4. Configurar la versión objetivo Java 17 en las recetas YAML y propagarla al generador.
+5. Integrar generación de pruebas unitarias que comparen DTO antes/después de la traducción.
+6. Documentar la extensión en `ARCHITECTURE.md` y preparar demos con programas COBOL reales.
+
+Este plan permitirá evolucionar de esqueletos a servicios Java funcionales respetando la lógica original de los programas COBOL.

--- a/cobol-openrewrite-recipes/pom.xml
+++ b/cobol-openrewrite-recipes/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.shark.renovatio</groupId>
+        <artifactId>renovatio-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>cobol-openrewrite-recipes</artifactId>
+    <name>Renovatio COBOL OpenRewrite Recipes</name>
+    <description>Recipes to enrich generated Java code from COBOL IR</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>renovatio-cobol-ir</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <version>${openrewrite.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/cobol-openrewrite-recipes/src/main/java/org/shark/renovatio/cobol/recipes/JavaTemplateSupport.java
+++ b/cobol-openrewrite-recipes/src/main/java/org/shark/renovatio/cobol/recipes/JavaTemplateSupport.java
@@ -1,0 +1,20 @@
+package org.shark.renovatio.cobol.recipes;
+
+import org.openrewrite.Cursor;
+import org.openrewrite.java.JavaTemplate;
+import org.openrewrite.java.tree.J;
+
+import java.util.Collections;
+
+final class JavaTemplateSupport {
+
+    private JavaTemplateSupport() {
+    }
+
+    static J.Block applyTemplate(Cursor cursor, J.Block body, String templateSource) {
+        JavaTemplate template = JavaTemplate.builder(cursor, templateSource)
+                .imports(Collections.emptyList())
+                .build();
+        return (J.Block) template.apply(cursor, body.getCoordinates().replace(), new Object[0]);
+    }
+}

--- a/cobol-openrewrite-recipes/src/main/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipe.java
+++ b/cobol-openrewrite-recipes/src/main/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipe.java
@@ -1,0 +1,257 @@
+package org.shark.renovatio.cobol.recipes;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.Option;
+import org.openrewrite.Preconditions;
+import org.openrewrite.internal.lang.Nullable;
+import org.openrewrite.java.JavaIsoVisitor;
+import org.openrewrite.java.tree.J;
+import org.shark.renovatio.cobol.ir.model.*;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
+public class PopulateCobolProcessRecipe extends org.openrewrite.Recipe {
+
+    public static final String CONTEXT_KEY = "renovatio.cobol.ir";
+
+    @Option(displayName = "Method name",
+            description = "Name of the method to populate with COBOL logic.",
+            example = "process",
+            required = false)
+    @Nullable
+    private final String methodName;
+
+    public PopulateCobolProcessRecipe() {
+        this("process");
+    }
+
+    public PopulateCobolProcessRecipe(@Nullable String methodName) {
+        this.methodName = methodName == null ? "process" : methodName;
+    }
+
+    @Override
+    public String getDisplayName() {
+        return "Populate COBOL service method";
+    }
+
+    @Override
+    public String getDescription() {
+        return "Replaces TODO markers in generated service methods with statements derived from the COBOL IR.";
+    }
+
+    @Override
+    public Duration getEstimatedEffortPerOccurrence() {
+        return Duration.ofSeconds(3);
+    }
+
+    @Override
+    protected TreeVisitor<?, ExecutionContext> getVisitor() {
+        return Preconditions.check(new TargetMethodPresent(), new PopulateVisitor());
+    }
+
+    private class TargetMethodPresent extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+            if (isTargetMethod(method) && method.getBody() != null && containsTodo(method.getBody())) {
+                return method;
+            }
+            return method;
+        }
+    }
+
+    private class PopulateVisitor extends JavaIsoVisitor<ExecutionContext> {
+        @Override
+        public J.MethodDeclaration visitMethodDeclaration(J.MethodDeclaration method, ExecutionContext ctx) {
+            CobolIntermediateModel model = ctx.getMessage(CONTEXT_KEY);
+            if (model == null) {
+                return method;
+            }
+            if (!isTargetMethod(method) || method.getBody() == null) {
+                return method;
+            }
+            if (!containsTodo(method.getBody())) {
+                return method;
+            }
+            List<String> rendered = renderParagraph(model.getEntryParagraph());
+            if (rendered.isEmpty()) {
+                return method;
+            }
+            String returnType = method.getReturnTypeExpression() != null
+                    ? method.getReturnTypeExpression().printTrimmed(getCursor())
+                    : "void";
+            String dtoType = !"void".equals(returnType) ? returnType : inferDtoTypeFromParameters(method);
+            if (dtoType == null) {
+                return method;
+            }
+            String bodyTemplate = buildBody(rendered, dtoType);
+            return method.withBody(JavaTemplateSupport.applyTemplate(getCursor(), method.getBody(), bodyTemplate));
+        }
+    }
+
+    private boolean isTargetMethod(J.MethodDeclaration method) {
+        return method.getSimpleName().equals(methodName);
+    }
+
+    private boolean containsTodo(J.Block body) {
+        return body.getStatements().stream()
+                .map(stmt -> stmt.printTrimmed())
+                .anyMatch(text -> text != null && text.contains("TODO"));
+    }
+
+    private List<String> renderParagraph(CobolParagraph paragraph) {
+        List<String> lines = new ArrayList<>();
+        for (CobolStatement statement : paragraph.getStatements()) {
+            if (statement instanceof MoveStatement move) {
+                lines.add(renderMove(move));
+                continue;
+            }
+            if (statement instanceof ComputeStatement compute) {
+                lines.add(renderCompute(compute));
+                continue;
+            }
+            if (statement instanceof IfStatement ifStatement) {
+                lines.addAll(renderIf(ifStatement));
+                continue;
+            }
+            if (statement instanceof PerformStatement perform) {
+                lines.add(renderPerform(perform));
+                continue;
+            }
+            if (statement instanceof Db2Statement db2) {
+                lines.add(renderDb2(db2));
+            }
+        }
+        return lines;
+    }
+
+    private List<String> renderIf(IfStatement ifStatement) {
+        List<String> lines = new ArrayList<>();
+        lines.add(String.format(Locale.ROOT, "if (%s) {", translateCondition(ifStatement.getCondition())));
+        for (CobolStatement stmt : ifStatement.getThenStatements()) {
+            lines.add(indent(renderSingle(stmt)));
+        }
+        if (!ifStatement.getElseStatements().isEmpty()) {
+            lines.add("} else {");
+            for (CobolStatement stmt : ifStatement.getElseStatements()) {
+                lines.add(indent(renderSingle(stmt)));
+            }
+        }
+        lines.add("}");
+        return lines;
+    }
+
+    private String renderSingle(CobolStatement statement) {
+        if (statement instanceof MoveStatement move) {
+            return renderMove(move);
+        }
+        if (statement instanceof ComputeStatement compute) {
+            return renderCompute(compute);
+        }
+        if (statement instanceof Db2Statement db2) {
+            return renderDb2(db2);
+        }
+        return "// Unhandled COBOL statement";
+    }
+
+    private String renderMove(MoveStatement move) {
+        return String.format(Locale.ROOT, "output.%s(%s);",
+                toSetter(move.getTarget()), toJavaExpression(move.getSource()));
+    }
+
+    private String renderCompute(ComputeStatement compute) {
+        return String.format(Locale.ROOT, "output.%s(%s);",
+                toSetter(compute.getTarget()), translateExpression(compute.getExpression()));
+    }
+
+    private String renderPerform(PerformStatement perform) {
+        return String.format(Locale.ROOT, "// TODO: PERFORM %s", perform.getParagraph());
+    }
+
+    private String renderDb2(Db2Statement db2) {
+        return String.format(Locale.ROOT, "// EXEC SQL %s", db2.getSql());
+    }
+
+    private String translateCondition(String condition) {
+        String javaCondition = condition
+                .replace("=", "==")
+                .replace("<>", "!=")
+                .replace("NOT =", "!=")
+                .replace("THEN", "");
+        return toJavaExpression(javaCondition.trim());
+    }
+
+    private String translateExpression(String expression) {
+        return expression
+                .replace("**,", "Math.pow")
+                .replace("\n", " ")
+                .trim();
+    }
+
+    private String toSetter(String cobolName) {
+        return "set" + toPascal(cobolName);
+    }
+
+    private String toJavaExpression(String value) {
+        if (value == null || value.isBlank()) {
+            return "null";
+        }
+        String trimmed = value.trim();
+        if (trimmed.startsWith("'")) {
+            return trimmed;
+        }
+        if (trimmed.matches("\".*\"")) {
+            return trimmed;
+        }
+        if (trimmed.matches("[0-9]+")) {
+            return trimmed;
+        }
+        if (trimmed.equalsIgnoreCase("TRUE") || trimmed.equalsIgnoreCase("FALSE")) {
+            return trimmed.toLowerCase(Locale.ROOT);
+        }
+        return String.format(Locale.ROOT, "input.get%s()", toPascal(trimmed));
+    }
+
+    private String toPascal(String cobolName) {
+        String normalized = cobolName.replace(".", "").replace("-", " ").trim();
+        String[] parts = normalized.split("\\s+");
+        StringBuilder sb = new StringBuilder();
+        for (String part : parts) {
+            if (part.isBlank()) {
+                continue;
+            }
+            sb.append(part.substring(0, 1).toUpperCase(Locale.ROOT))
+                    .append(part.substring(1).toLowerCase(Locale.ROOT));
+        }
+        return sb.toString();
+    }
+
+    private String indent(String value) {
+        return "    " + value;
+    }
+
+    private String buildBody(List<String> statements, String dtoType) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("{\n");
+        builder.append(String.format(Locale.ROOT, "    %s output = new %s();\n", dtoType, dtoType));
+        for (String statement : statements) {
+            builder.append("    ").append(statement).append('\n');
+        }
+        builder.append("    return output;\n");
+        builder.append("}");
+        return builder.toString();
+    }
+
+    private String inferDtoTypeFromParameters(J.MethodDeclaration method) {
+        if (method.getParameters().isEmpty()) {
+            return null;
+        }
+        J first = method.getParameters().get(0);
+        if (first instanceof J.VariableDeclarations declarations && declarations.getTypeExpression() != null) {
+            return declarations.getTypeExpression().printTrimmed(getCursor());
+        }
+        return null;
+    }
+}

--- a/cobol-openrewrite-recipes/src/main/resources/META-INF/rewrite/cobol.yml
+++ b/cobol-openrewrite-recipes/src/main/resources/META-INF/rewrite/cobol.yml
@@ -1,0 +1,8 @@
+type: specs.openrewrite.org/v1beta/recipe
+name: org.shark.renovatio.cobol.recipes.PopulateCobolProcessRecipe
+displayName: Populate COBOL process method
+description: Populate generated service methods with statements derived from the COBOL IR.
+recipeList:
+  - org.openrewrite.java.search.HasMinimumJavaVersion:
+      version: '17'
+  - org.shark.renovatio.cobol.recipes.PopulateCobolProcessRecipe

--- a/cobol-openrewrite-recipes/src/test/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipeTest.java
+++ b/cobol-openrewrite-recipes/src/test/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipeTest.java
@@ -1,0 +1,67 @@
+package org.shark.renovatio.cobol.recipes;
+
+import org.junit.jupiter.api.Test;
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Result;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.shark.renovatio.cobol.ir.model.CobolIntermediateModel;
+import org.shark.renovatio.cobol.ir.parser.SimpleCobolIrParser;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PopulateCobolProcessRecipeTest {
+
+    private static final String COBOL_SAMPLE = """
+            IDENTIFICATION DIVISION.
+            PROGRAM-ID. SAMPLE1.
+            DATA DIVISION.
+            WORKING-STORAGE SECTION.
+            01 CUSTOMER-NAME PIC X(30).
+            01 CUSTOMER-RATING PIC 9(2).
+            PROCEDURE DIVISION.
+            MAIN-PARA.
+                MOVE 'JOHN' TO CUSTOMER-NAME.
+                IF CUSTOMER-RATING > 80
+                    MOVE 'VIP' TO CUSTOMER-NAME
+                ELSE
+                    MOVE 'STANDARD' TO CUSTOMER-NAME
+                END-IF.
+                GOBACK.
+            END-PARA.
+            """;
+
+    @Test
+    void shouldPopulateProcessMethodWithCobolLogic() {
+        SimpleCobolIrParser parser = new SimpleCobolIrParser();
+        CobolIntermediateModel model = parser.parse(COBOL_SAMPLE);
+
+        String javaSource = """
+                package sample;
+                public class SampleService {
+                    public SampleDto process(SampleDto input) {
+                        // TODO: Implement COBOL business logic
+                        SampleDto output = new SampleDto();
+                        return output;
+                    }
+                }
+                """;
+
+        JavaParser javaParser = JavaParser.fromJavaVersion().build();
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        ctx.putMessage(PopulateCobolProcessRecipe.CONTEXT_KEY, model);
+
+        List<J.CompilationUnit> cus = javaParser.parse(ctx, javaSource);
+        PopulateCobolProcessRecipe recipe = new PopulateCobolProcessRecipe();
+        List<Result> results = recipe.run(cus, ctx).getChangeset().getAllResults();
+
+        assertThat(results).hasSize(1);
+        String updated = results.get(0).getAfter().printAll();
+        assertThat(updated).contains("output.setCustomerName('JOHN');");
+        assertThat(updated).contains("if (input.getCustomerRating() > 80)");
+        assertThat(updated).doesNotContain("TODO");
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,8 @@
         <module>renovatio-provider-java</module>
         <module>renovatio-provider-cobol</module>
         <module>renovatio-mcp-server</module>
+        <module>renovatio-cobol-ir</module>
+        <module>cobol-openrewrite-recipes</module>
     </modules>
 
     <dependencyManagement>
@@ -63,6 +65,16 @@
             <dependency>
                 <groupId>org.shark.renovatio</groupId>
                 <artifactId>renovatio-provider-cobol</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.shark.renovatio</groupId>
+                <artifactId>renovatio-cobol-ir</artifactId>
+                <version>${project.version}</version>
+            </dependency>
+            <dependency>
+                <groupId>org.shark.renovatio</groupId>
+                <artifactId>cobol-openrewrite-recipes</artifactId>
                 <version>${project.version}</version>
             </dependency>
 

--- a/renovatio-cobol-ir/pom.xml
+++ b/renovatio-cobol-ir/pom.xml
@@ -1,0 +1,45 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <groupId>org.shark.renovatio</groupId>
+        <artifactId>renovatio-parent</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>renovatio-cobol-ir</artifactId>
+    <name>Renovatio COBOL Intermediate Representation</name>
+    <description>Intermediate model and parsing utilities for COBOL programs</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>renovatio-shared</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter</artifactId>
+            <scope>test</scope>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <configuration>
+                    <useModulePath>false</useModulePath>
+                </configuration>
+            </plugin>
+        </plugins>
+    </build>
+</project>

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/context/CobolExecutionContext.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/context/CobolExecutionContext.java
@@ -1,0 +1,75 @@
+package org.shark.renovatio.cobol.ir.context;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+public final class CobolExecutionContext {
+
+    private final Map<String, String> variableScopes;
+    private final Map<String, Object> attributes;
+
+    private CobolExecutionContext(Map<String, String> variableScopes, Map<String, Object> attributes) {
+        this.variableScopes = Collections.unmodifiableMap(variableScopes);
+        this.attributes = Collections.unmodifiableMap(attributes);
+    }
+
+    public Optional<String> resolveScope(String variable) {
+        if (variable == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(variableScopes.get(variable.toUpperCase()));
+    }
+
+    public Optional<Object> attribute(String key) {
+        return Optional.ofNullable(attributes.get(key));
+    }
+
+    public Map<String, String> getVariableScopes() {
+        return variableScopes;
+    }
+
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    public static CobolExecutionContext empty() {
+        return new CobolExecutionContext(Map.of(), Map.of());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private final Map<String, String> scopes = new LinkedHashMap<>();
+        private final Map<String, Object> attributes = new LinkedHashMap<>();
+
+        public Builder registerVariable(String name, String scope) {
+            if (name != null && scope != null) {
+                scopes.put(name.toUpperCase(), scope.toLowerCase());
+            }
+            return this;
+        }
+
+        public Builder registerVariables(Set<String> names, String scope) {
+            if (names != null) {
+                names.forEach(name -> registerVariable(name, scope));
+            }
+            return this;
+        }
+
+        public Builder attribute(String key, Object value) {
+            if (key != null && value != null) {
+                attributes.put(key, value);
+            }
+            return this;
+        }
+
+        public CobolExecutionContext build() {
+            return new CobolExecutionContext(new LinkedHashMap<>(scopes), new LinkedHashMap<>(attributes));
+        }
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/context/CobolTypeMapper.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/context/CobolTypeMapper.java
@@ -1,0 +1,40 @@
+package org.shark.renovatio.cobol.ir.context;
+
+import java.math.BigDecimal;
+import java.util.Locale;
+
+public final class CobolTypeMapper {
+
+    private CobolTypeMapper() {
+    }
+
+    public static String picToJavaType(String pic) {
+        if (pic == null || pic.isBlank()) {
+            return String.class.getSimpleName();
+        }
+        String normalized = pic.trim().toUpperCase(Locale.ROOT);
+        if (normalized.startsWith("PIC")) {
+            normalized = normalized.substring(3).trim();
+        }
+        if (normalized.matches("9\\(\\d+\\)")) {
+            int digits = Integer.parseInt(normalized.replaceAll("[^0-9]", ""));
+            if (digits <= 9) {
+                return Integer.class.getSimpleName();
+            }
+            if (digits <= 18) {
+                return Long.class.getSimpleName();
+            }
+            return BigDecimal.class.getSimpleName();
+        }
+        if (normalized.matches("9\\(\\d+\\)V9+")) {
+            return BigDecimal.class.getSimpleName();
+        }
+        if (normalized.startsWith("X") || normalized.startsWith("A")) {
+            return String.class.getSimpleName();
+        }
+        if (normalized.contains("COMP")) {
+            return Integer.class.getSimpleName();
+        }
+        return String.class.getSimpleName();
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/flow/ControlFlowGraph.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/flow/ControlFlowGraph.java
@@ -1,0 +1,63 @@
+package org.shark.renovatio.cobol.ir.flow;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+
+public final class ControlFlowGraph {
+
+    private final Map<String, Set<String>> adjacency;
+
+    private ControlFlowGraph(Map<String, Set<String>> adjacency) {
+        this.adjacency = Collections.unmodifiableMap(adjacency);
+    }
+
+    public Map<String, Set<String>> getAdjacency() {
+        return adjacency;
+    }
+
+    public Set<String> successors(String node) {
+        if (node == null) {
+            return Set.of();
+        }
+        return adjacency.getOrDefault(node.toUpperCase(), Set.of());
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static ControlFlowGraph empty() {
+        return new ControlFlowGraph(Map.of());
+    }
+
+    public static final class Builder {
+        private final Map<String, Set<String>> adjacency = new LinkedHashMap<>();
+
+        public Builder addEdge(String from, String to) {
+            if (from == null || to == null) {
+                return this;
+            }
+            adjacency.computeIfAbsent(from.toUpperCase(), k -> new LinkedHashSet<>())
+                    .add(to.toUpperCase());
+            adjacency.putIfAbsent(to.toUpperCase(), new LinkedHashSet<>());
+            return this;
+        }
+
+        public Builder ensureNode(String node) {
+            if (node != null) {
+                adjacency.putIfAbsent(node.toUpperCase(), new LinkedHashSet<>());
+            }
+            return this;
+        }
+
+        public ControlFlowGraph build() {
+            Map<String, Set<String>> copy = new LinkedHashMap<>();
+            adjacency.forEach((k, v) -> copy.put(k, Collections.unmodifiableSet(new LinkedHashSet<>(v))));
+            return new ControlFlowGraph(copy);
+        }
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CallStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CallStatement.java
@@ -1,0 +1,23 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class CallStatement implements CobolStatement {
+
+    private final String target;
+    private final List<String> arguments;
+
+    public CallStatement(String target, List<String> arguments) {
+        this.target = Objects.requireNonNull(target, "target");
+        this.arguments = List.copyOf(arguments == null ? List.of() : arguments);
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public List<String> getArguments() {
+        return arguments;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolDataItem.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolDataItem.java
@@ -1,0 +1,47 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.Objects;
+import java.util.Optional;
+
+public final class CobolDataItem {
+
+    private final String name;
+    private final String picture;
+    private final int level;
+    private final Integer occurs;
+    private final String redefines;
+    private final String javaType;
+
+    public CobolDataItem(String name, String picture, int level, Integer occurs, String redefines, String javaType) {
+        this.name = Objects.requireNonNull(name, "name");
+        this.picture = picture;
+        this.level = level;
+        this.occurs = occurs;
+        this.redefines = redefines;
+        this.javaType = javaType == null ? "String" : javaType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getPicture() {
+        return picture;
+    }
+
+    public int getLevel() {
+        return level;
+    }
+
+    public Optional<Integer> getOccurs() {
+        return Optional.ofNullable(occurs);
+    }
+
+    public Optional<String> getRedefines() {
+        return Optional.ofNullable(redefines);
+    }
+
+    public String getJavaType() {
+        return javaType;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolIntermediateModel.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolIntermediateModel.java
@@ -1,0 +1,112 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import org.shark.renovatio.cobol.ir.context.CobolExecutionContext;
+import org.shark.renovatio.cobol.ir.flow.ControlFlowGraph;
+
+import java.util.Collections;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+
+/**
+ * Immutable representation of a COBOL program that has been normalised into a
+ * structure convenient for downstream translators.
+ */
+public final class CobolIntermediateModel {
+
+    private final String programId;
+    private final Map<String, CobolParagraph> paragraphs;
+    private final List<CobolDataItem> dataItems;
+    private final ControlFlowGraph controlFlowGraph;
+    private final CobolExecutionContext executionContext;
+
+    private CobolIntermediateModel(Builder builder) {
+        this.programId = builder.programId;
+        this.paragraphs = Collections.unmodifiableMap(new LinkedHashMap<>(builder.paragraphs));
+        this.dataItems = List.copyOf(builder.dataItems);
+        this.controlFlowGraph = builder.controlFlowGraph;
+        this.executionContext = builder.executionContext;
+    }
+
+    public String getProgramId() {
+        return programId;
+    }
+
+    public Map<String, CobolParagraph> getParagraphs() {
+        return paragraphs;
+    }
+
+    public List<CobolDataItem> getDataItems() {
+        return dataItems;
+    }
+
+    public ControlFlowGraph getControlFlowGraph() {
+        return controlFlowGraph;
+    }
+
+    public CobolExecutionContext getExecutionContext() {
+        return executionContext;
+    }
+
+    public Optional<CobolParagraph> findParagraph(String name) {
+        if (name == null) {
+            return Optional.empty();
+        }
+        return Optional.ofNullable(paragraphs.get(name.toUpperCase()));
+    }
+
+    public CobolParagraph getEntryParagraph() {
+        if (paragraphs.isEmpty()) {
+            return CobolParagraph.empty("MAIN");
+        }
+        return paragraphs.values().iterator().next();
+    }
+
+    public static Builder builder() {
+        return new Builder();
+    }
+
+    public static final class Builder {
+        private String programId;
+        private final Map<String, CobolParagraph> paragraphs = new LinkedHashMap<>();
+        private List<CobolDataItem> dataItems = List.of();
+        private ControlFlowGraph controlFlowGraph = ControlFlowGraph.empty();
+        private CobolExecutionContext executionContext = CobolExecutionContext.empty();
+
+        private Builder() {
+        }
+
+        public Builder programId(String programId) {
+            this.programId = Objects.requireNonNull(programId, "programId").toUpperCase();
+            return this;
+        }
+
+        public Builder addParagraph(CobolParagraph paragraph) {
+            Objects.requireNonNull(paragraph, "paragraph");
+            this.paragraphs.put(paragraph.getName().toUpperCase(), paragraph);
+            return this;
+        }
+
+        public Builder dataItems(List<CobolDataItem> dataItems) {
+            this.dataItems = dataItems == null ? List.of() : List.copyOf(dataItems);
+            return this;
+        }
+
+        public Builder controlFlowGraph(ControlFlowGraph controlFlowGraph) {
+            this.controlFlowGraph = controlFlowGraph == null ? ControlFlowGraph.empty() : controlFlowGraph;
+            return this;
+        }
+
+        public Builder executionContext(CobolExecutionContext executionContext) {
+            this.executionContext = executionContext == null ? CobolExecutionContext.empty() : executionContext;
+            return this;
+        }
+
+        public CobolIntermediateModel build() {
+            Objects.requireNonNull(programId, "programId");
+            return new CobolIntermediateModel(this);
+        }
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolParagraph.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolParagraph.java
@@ -1,0 +1,29 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Objects;
+
+public final class CobolParagraph {
+
+    private final String name;
+    private final List<CobolStatement> statements;
+
+    public CobolParagraph(String name, List<CobolStatement> statements) {
+        this.name = Objects.requireNonNull(name, "name").toUpperCase();
+        this.statements = Collections.unmodifiableList(new ArrayList<>(statements == null ? List.of() : statements));
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<CobolStatement> getStatements() {
+        return statements;
+    }
+
+    public static CobolParagraph empty(String name) {
+        return new CobolParagraph(name, List.of());
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/CobolStatement.java
@@ -1,0 +1,4 @@
+package org.shark.renovatio.cobol.ir.model;
+
+public interface CobolStatement {
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/ComputeStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/ComputeStatement.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.Objects;
+
+public final class ComputeStatement implements CobolStatement {
+
+    private final String target;
+    private final String expression;
+
+    public ComputeStatement(String target, String expression) {
+        this.target = Objects.requireNonNull(target, "target");
+        this.expression = Objects.requireNonNull(expression, "expression");
+    }
+
+    public String getTarget() {
+        return target;
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/Db2Statement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/Db2Statement.java
@@ -1,0 +1,16 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.Objects;
+
+public final class Db2Statement implements CobolStatement {
+
+    private final String sql;
+
+    public Db2Statement(String sql) {
+        this.sql = Objects.requireNonNull(sql, "sql");
+    }
+
+    public String getSql() {
+        return sql;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/EvaluateStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/EvaluateStatement.java
@@ -1,0 +1,41 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class EvaluateStatement implements CobolStatement {
+
+    private final String expression;
+    private final List<EvaluateWhenBranch> branches;
+
+    public EvaluateStatement(String expression, List<EvaluateWhenBranch> branches) {
+        this.expression = Objects.requireNonNull(expression, "expression");
+        this.branches = List.copyOf(branches == null ? List.of() : branches);
+    }
+
+    public String getExpression() {
+        return expression;
+    }
+
+    public List<EvaluateWhenBranch> getBranches() {
+        return branches;
+    }
+
+    public static final class EvaluateWhenBranch {
+        private final String condition;
+        private final List<CobolStatement> statements;
+
+        public EvaluateWhenBranch(String condition, List<CobolStatement> statements) {
+            this.condition = Objects.requireNonNull(condition, "condition");
+            this.statements = List.copyOf(statements == null ? List.of() : statements);
+        }
+
+        public String getCondition() {
+            return condition;
+        }
+
+        public List<CobolStatement> getStatements() {
+            return statements;
+        }
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/FileOperationStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/FileOperationStatement.java
@@ -1,0 +1,31 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.Objects;
+
+public final class FileOperationStatement implements CobolStatement {
+
+    public enum OperationType {
+        READ,
+        WRITE,
+        REWRITE,
+        DELETE,
+        OPEN,
+        CLOSE
+    }
+
+    private final OperationType operationType;
+    private final String fileName;
+
+    public FileOperationStatement(OperationType operationType, String fileName) {
+        this.operationType = Objects.requireNonNull(operationType, "operationType");
+        this.fileName = Objects.requireNonNull(fileName, "fileName");
+    }
+
+    public OperationType getOperationType() {
+        return operationType;
+    }
+
+    public String getFileName() {
+        return fileName;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/IfStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/IfStatement.java
@@ -1,0 +1,31 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.List;
+import java.util.Objects;
+
+public final class IfStatement implements CobolStatement {
+
+    private final String condition;
+    private final List<CobolStatement> thenStatements;
+    private final List<CobolStatement> elseStatements;
+
+    public IfStatement(String condition,
+                       List<CobolStatement> thenStatements,
+                       List<CobolStatement> elseStatements) {
+        this.condition = Objects.requireNonNull(condition, "condition");
+        this.thenStatements = List.copyOf(thenStatements == null ? List.of() : thenStatements);
+        this.elseStatements = List.copyOf(elseStatements == null ? List.of() : elseStatements);
+    }
+
+    public String getCondition() {
+        return condition;
+    }
+
+    public List<CobolStatement> getThenStatements() {
+        return thenStatements;
+    }
+
+    public List<CobolStatement> getElseStatements() {
+        return elseStatements;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/MoveStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/MoveStatement.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.Objects;
+
+public final class MoveStatement implements CobolStatement {
+
+    private final String source;
+    private final String target;
+
+    public MoveStatement(String source, String target) {
+        this.source = Objects.requireNonNull(source, "source");
+        this.target = Objects.requireNonNull(target, "target");
+    }
+
+    public String getSource() {
+        return source;
+    }
+
+    public String getTarget() {
+        return target;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/PerformStatement.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/model/PerformStatement.java
@@ -1,0 +1,22 @@
+package org.shark.renovatio.cobol.ir.model;
+
+import java.util.Objects;
+
+public final class PerformStatement implements CobolStatement {
+
+    private final String paragraph;
+    private final String throughParagraph;
+
+    public PerformStatement(String paragraph, String throughParagraph) {
+        this.paragraph = Objects.requireNonNull(paragraph, "paragraph").toUpperCase();
+        this.throughParagraph = throughParagraph != null ? throughParagraph.toUpperCase() : null;
+    }
+
+    public String getParagraph() {
+        return paragraph;
+    }
+
+    public String getThroughParagraph() {
+        return throughParagraph;
+    }
+}

--- a/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/parser/SimpleCobolIrParser.java
+++ b/renovatio-cobol-ir/src/main/java/org/shark/renovatio/cobol/ir/parser/SimpleCobolIrParser.java
@@ -1,0 +1,331 @@
+package org.shark.renovatio.cobol.ir.parser;
+
+import org.apache.commons.lang3.StringUtils;
+import org.shark.renovatio.cobol.ir.context.CobolExecutionContext;
+import org.shark.renovatio.cobol.ir.context.CobolTypeMapper;
+import org.shark.renovatio.cobol.ir.flow.ControlFlowGraph;
+import org.shark.renovatio.cobol.ir.model.*;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Lightweight IR parser that extracts an executable structure from COBOL
+ * programs without requiring the full ProLeap dependency at runtime.  The
+ * implementation intentionally focuses on a subset of the language that is
+ * sufficient to drive the first iteration of the Java translator while keeping
+ * the code easy to understand and extend.
+ */
+public class SimpleCobolIrParser {
+
+    private static final Pattern PROGRAM_ID_PATTERN = Pattern.compile("PROGRAM-ID\\.\\s*([A-Z0-9-]+)", Pattern.CASE_INSENSITIVE);
+    private static final Pattern DATA_ITEM_PATTERN = Pattern.compile("(?m)^(\\s*)(\\d{2})\\s+([A-Z0-9-]+)(?:\\s+REDEFINES\\s+([A-Z0-9-]+))?\\s+PIC\\s+([^\.]+)\\.");
+    private static final Pattern PARAGRAPH_PATTERN = Pattern.compile("(?ms)^(?<!-) {0,6}([A-Z][A-Z0-9-]*)\\.(.*?)(?=^(?<!-) {0,6}[A-Z][A-Z0-9-]*\\.|\\Z)");
+    private static final Pattern EXEC_SQL_PATTERN = Pattern.compile("EXEC\\s+SQL(.*?)END-EXEC", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
+
+    public CobolIntermediateModel parse(Path cobolFile) throws IOException {
+        String source = Files.readString(cobolFile);
+        return parse(source);
+    }
+
+    public CobolIntermediateModel parse(String source) {
+        if (source == null) {
+            throw new IllegalArgumentException("source must not be null");
+        }
+        String programId = extractProgramId(source);
+        List<CobolDataItem> dataItems = extractDataItems(source);
+        Map<String, CobolParagraph> paragraphs = extractParagraphs(source);
+        ControlFlowGraph flowGraph = buildControlFlowGraph(paragraphs);
+
+        CobolExecutionContext.Builder contextBuilder = CobolExecutionContext.builder();
+        Set<String> workingStorageNames = new LinkedHashSet<>();
+        for (CobolDataItem item : dataItems) {
+            workingStorageNames.add(item.getName().toUpperCase(Locale.ROOT));
+        }
+        contextBuilder.registerVariables(workingStorageNames, "working-storage");
+        contextBuilder.attribute("programId", programId);
+
+        CobolIntermediateModel.Builder builder = CobolIntermediateModel.builder()
+                .programId(programId)
+                .dataItems(dataItems)
+                .controlFlowGraph(flowGraph)
+                .executionContext(contextBuilder.build());
+        paragraphs.values().forEach(builder::addParagraph);
+        return builder.build();
+    }
+
+    private String extractProgramId(String source) {
+        Matcher matcher = PROGRAM_ID_PATTERN.matcher(source);
+        if (matcher.find()) {
+            return matcher.group(1).toUpperCase(Locale.ROOT);
+        }
+        return "COBOLPROGRAM";
+    }
+
+    private List<CobolDataItem> extractDataItems(String source) {
+        Matcher matcher = DATA_ITEM_PATTERN.matcher(source);
+        List<CobolDataItem> items = new ArrayList<>();
+        while (matcher.find()) {
+            int level = Integer.parseInt(matcher.group(2));
+            String name = matcher.group(3).toUpperCase(Locale.ROOT);
+            String redefines = matcher.group(4) != null ? matcher.group(4).toUpperCase(Locale.ROOT) : null;
+            String pic = matcher.group(5).trim();
+            String javaType = CobolTypeMapper.picToJavaType(pic);
+            items.add(new CobolDataItem(name, pic, level, null, redefines, javaType));
+        }
+        return items;
+    }
+
+    private Map<String, CobolParagraph> extractParagraphs(String source) {
+        Matcher matcher = PARAGRAPH_PATTERN.matcher(extractProcedureDivision(source));
+        Map<String, CobolParagraph> paragraphs = new LinkedHashMap<>();
+        while (matcher.find()) {
+            String name = matcher.group(1).toUpperCase(Locale.ROOT);
+            String body = matcher.group(2);
+            List<CobolStatement> statements = parseStatements(body);
+            paragraphs.put(name, new CobolParagraph(name, statements));
+        }
+        if (paragraphs.isEmpty()) {
+            paragraphs.put("MAIN", CobolParagraph.empty("MAIN"));
+        }
+        return paragraphs;
+    }
+
+    private String extractProcedureDivision(String source) {
+        int procIdx = StringUtils.indexOfIgnoreCase(source, "PROCEDURE DIVISION");
+        if (procIdx < 0) {
+            return source;
+        }
+        return source.substring(procIdx);
+    }
+
+    private List<CobolStatement> parseStatements(String block) {
+        List<CobolStatement> statements = new ArrayList<>();
+        List<String> lines = Arrays.asList(block.split("\n"));
+        for (int i = 0; i < lines.size(); i++) {
+            String line = lines.get(i).trim();
+            if (line.isEmpty()) {
+                continue;
+            }
+            if (line.startsWith("IF ")) {
+                i = parseIf(lines, i, statements);
+                continue;
+            }
+            if (line.startsWith("EVALUATE")) {
+                i = parseEvaluate(lines, i, statements);
+                continue;
+            }
+            if (line.startsWith("PERFORM")) {
+                statements.add(parsePerform(line));
+                continue;
+            }
+            if (line.startsWith("CALL")) {
+                statements.add(parseCall(line));
+                continue;
+            }
+            if (line.startsWith("EXEC SQL")) {
+                i = parseExecSql(lines, i, statements);
+                continue;
+            }
+            FileOperationStatement.OperationType op = detectFileOperation(line);
+            if (op != null) {
+                statements.add(new FileOperationStatement(op, parseFileName(line)));
+                continue;
+            }
+            if (line.startsWith("COMPUTE")) {
+                statements.add(parseCompute(line));
+                continue;
+            }
+            if (line.startsWith("MOVE")) {
+                statements.add(parseMove(line));
+            }
+        }
+        return statements;
+    }
+
+    private int parseIf(List<String> lines, int index, List<CobolStatement> statements) {
+        String line = lines.get(index).trim();
+        String condition = line.substring(2).trim();
+        List<String> thenLines = new ArrayList<>();
+        List<String> elseLines = new ArrayList<>();
+        boolean inElse = false;
+        int i = index + 1;
+        for (; i < lines.size(); i++) {
+            String current = lines.get(i).trim();
+            if (current.isEmpty()) {
+                continue;
+            }
+            if (current.startsWith("ELSE")) {
+                inElse = true;
+                String afterElse = current.substring(4).trim();
+                if (!afterElse.isEmpty() && !afterElse.equals(".")) {
+                    (inElse ? elseLines : thenLines).add(afterElse);
+                }
+                continue;
+            }
+            if (current.startsWith("END-IF")) {
+                break;
+            }
+            if (inElse) {
+                elseLines.add(current);
+            } else {
+                thenLines.add(current);
+            }
+        }
+        statements.add(new IfStatement(normalizeCondition(condition),
+                parseStatements(String.join("\n", thenLines)),
+                parseStatements(String.join("\n", elseLines))));
+        return i;
+    }
+
+    private int parseEvaluate(List<String> lines, int index, List<CobolStatement> statements) {
+        String expression = lines.get(index).trim().substring("EVALUATE".length()).trim();
+        List<EvaluateStatement.EvaluateWhenBranch> branches = new ArrayList<>();
+        List<String> accumulator = new ArrayList<>();
+        String currentCondition = "OTHER";
+        int i = index + 1;
+        for (; i < lines.size(); i++) {
+            String current = lines.get(i).trim();
+            if (current.startsWith("WHEN")) {
+                if (!accumulator.isEmpty()) {
+                    branches.add(new EvaluateStatement.EvaluateWhenBranch(currentCondition,
+                            parseStatements(String.join("\n", accumulator))));
+                    accumulator.clear();
+                }
+                currentCondition = current.substring(4).trim();
+                continue;
+            }
+            if (current.startsWith("WHEN OTHER")) {
+                if (!accumulator.isEmpty()) {
+                    branches.add(new EvaluateStatement.EvaluateWhenBranch(currentCondition,
+                            parseStatements(String.join("\n", accumulator))));
+                    accumulator.clear();
+                }
+                currentCondition = "OTHER";
+                continue;
+            }
+            if (current.startsWith("END-EVALUATE")) {
+                break;
+            }
+            accumulator.add(current);
+        }
+        if (!accumulator.isEmpty()) {
+            branches.add(new EvaluateStatement.EvaluateWhenBranch(currentCondition,
+                    parseStatements(String.join("\n", accumulator))));
+        }
+        statements.add(new EvaluateStatement(expression, branches));
+        return i;
+    }
+
+    private int parseExecSql(List<String> lines, int index, List<CobolStatement> statements) {
+        StringBuilder sql = new StringBuilder();
+        for (int i = index; i < lines.size(); i++) {
+            String current = lines.get(i);
+            sql.append(current).append('\n');
+            if (current.trim().toUpperCase(Locale.ROOT).contains("END-EXEC")) {
+                statements.add(new Db2Statement(cleanSql(sql.toString())));
+                return i;
+            }
+        }
+        statements.add(new Db2Statement(cleanSql(sql.toString())));
+        return lines.size();
+    }
+
+    private String cleanSql(String raw) {
+        Matcher matcher = EXEC_SQL_PATTERN.matcher(raw);
+        if (matcher.find()) {
+            return matcher.group(1).replaceAll("\n", " ").trim();
+        }
+        return raw.replaceAll("EXEC\\s+SQL", "").replace("END-EXEC", "").trim();
+    }
+
+    private PerformStatement parsePerform(String line) {
+        String withoutPerform = line.substring("PERFORM".length()).trim();
+        String[] parts = withoutPerform.split("\\s+THRU\\s+", 2);
+        String first = parts[0].replace(".", "").trim();
+        String thru = parts.length > 1 ? parts[1].replace(".", "").trim() : null;
+        return new PerformStatement(first, thru);
+    }
+
+    private CobolStatement parseCall(String line) {
+        String remainder = line.substring("CALL".length()).trim();
+        String[] parts = remainder.split("\s+USING\s+", 2);
+        String target = parts[0].replace("\"", "").replace("'", "");
+        List<String> args = new ArrayList<>();
+        if (parts.length > 1) {
+            args.addAll(Arrays.stream(parts[1].split(",|\s+")).map(String::trim).filter(s -> !s.isEmpty()).toList());
+        }
+        return new CallStatement(target, args);
+    }
+
+    private FileOperationStatement.OperationType detectFileOperation(String line) {
+        for (FileOperationStatement.OperationType type : FileOperationStatement.OperationType.values()) {
+            if (line.startsWith(type.name())) {
+                return type;
+            }
+        }
+        return null;
+    }
+
+    private String parseFileName(String line) {
+        String[] parts = line.split("\\s+");
+        return parts.length > 1 ? parts[1].replace(".", "").toUpperCase(Locale.ROOT) : "UNKNOWN";
+    }
+
+    private ComputeStatement parseCompute(String line) {
+        String remainder = line.substring("COMPUTE".length()).trim();
+        String[] parts = remainder.split("=", 2);
+        if (parts.length != 2) {
+            return new ComputeStatement("RESULT", remainder);
+        }
+        String target = parts[0].trim();
+        String expression = parts[1].replace(".", "").trim();
+        return new ComputeStatement(target, expression);
+    }
+
+    private MoveStatement parseMove(String line) {
+        String trimmed = line.replace(".", "").trim();
+        String remainder = trimmed.substring("MOVE".length()).trim();
+        String[] parts = remainder.split("\\s+TO\\s+", 2);
+        if (parts.length != 2) {
+            return new MoveStatement(remainder, remainder);
+        }
+        return new MoveStatement(parts[0].trim(), parts[1].trim());
+    }
+
+    private String normalizeCondition(String condition) {
+        return condition.replace("THEN", "").replace(".", "").trim();
+    }
+
+    private ControlFlowGraph buildControlFlowGraph(Map<String, CobolParagraph> paragraphs) {
+        ControlFlowGraph.Builder builder = ControlFlowGraph.builder();
+        String previous = null;
+        for (CobolParagraph paragraph : paragraphs.values()) {
+            builder.ensureNode(paragraph.getName());
+            if (previous != null) {
+                builder.addEdge(previous, paragraph.getName());
+            }
+            previous = paragraph.getName();
+            for (CobolStatement statement : paragraph.getStatements()) {
+                if (statement instanceof PerformStatement perform) {
+                    builder.addEdge(paragraph.getName(), perform.getParagraph());
+                    if (perform.getThroughParagraph() != null) {
+                        builder.addEdge(perform.getParagraph(), perform.getThroughParagraph());
+                    }
+                }
+            }
+        }
+        return builder.build();
+    }
+}

--- a/renovatio-cobol-ir/src/test/java/org/shark/renovatio/cobol/ir/parser/SimpleCobolIrParserTest.java
+++ b/renovatio-cobol-ir/src/test/java/org/shark/renovatio/cobol/ir/parser/SimpleCobolIrParserTest.java
@@ -1,0 +1,58 @@
+package org.shark.renovatio.cobol.ir.parser;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.cobol.ir.model.CobolIntermediateModel;
+import org.shark.renovatio.cobol.ir.model.CobolParagraph;
+import org.shark.renovatio.cobol.ir.model.IfStatement;
+import org.shark.renovatio.cobol.ir.model.MoveStatement;
+
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+class SimpleCobolIrParserTest {
+
+    private static final String COBOL_SAMPLE = """
+            IDENTIFICATION DIVISION.
+            PROGRAM-ID. SAMPLE1.
+            DATA DIVISION.
+            WORKING-STORAGE SECTION.
+            01 CUSTOMER-NAME PIC X(30).
+            01 CUSTOMER-RATING PIC 9(2).
+            PROCEDURE DIVISION.
+            MAIN-PARA.
+                MOVE 'JOHN' TO CUSTOMER-NAME.
+                IF CUSTOMER-RATING > 80
+                    MOVE 'VIP' TO CUSTOMER-NAME
+                ELSE
+                    MOVE 'STANDARD' TO CUSTOMER-NAME
+                END-IF.
+                GOBACK.
+            END-PARA.
+            """;
+
+    @Test
+    void shouldParseProgramIdDataItemsAndIfStructure() {
+        SimpleCobolIrParser parser = new SimpleCobolIrParser();
+        CobolIntermediateModel model = parser.parse(COBOL_SAMPLE);
+
+        assertEquals("SAMPLE1", model.getProgramId());
+        assertEquals(2, model.getDataItems().size());
+
+        CobolParagraph main = model.getEntryParagraph();
+        assertEquals("MAIN-PARA", main.getName());
+        assertFalse(main.getStatements().isEmpty());
+
+        MoveStatement move = (MoveStatement) main.getStatements().get(0);
+        assertEquals("'JOHN'", move.getSource());
+        assertEquals("CUSTOMER-NAME", move.getTarget());
+
+        IfStatement ifStatement = (IfStatement) main.getStatements().stream()
+                .filter(stmt -> stmt instanceof IfStatement)
+                .findFirst()
+                .orElseThrow();
+        assertEquals("CUSTOMER-RATING > 80", ifStatement.getCondition());
+        List<CobolParagraph> paragraphs = model.getParagraphs().values().stream().toList();
+        assertEquals(2, paragraphs.size());
+    }
+}

--- a/renovatio-provider-cobol/pom.xml
+++ b/renovatio-provider-cobol/pom.xml
@@ -20,6 +20,18 @@
             <artifactId>renovatio-shared</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>renovatio-cobol-ir</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>cobol-openrewrite-recipes</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.shark.renovatio</groupId>
+            <artifactId>renovatio-provider-java</artifactId>
+        </dependency>
+        <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context</artifactId>
             <exclusions>
@@ -73,6 +85,12 @@
             <artifactId>lucene-analysis-common</artifactId>
         </dependency>
 
+        <dependency>
+            <groupId>org.openrewrite</groupId>
+            <artifactId>rewrite-java</artifactId>
+            <version>${openrewrite.version}</version>
+        </dependency>
+
         <!-- Git operations -->
         <dependency>
             <groupId>org.eclipse.jgit</groupId>
@@ -90,6 +108,13 @@
                     <artifactId>commons-logging</artifactId>
                 </exclusion>
             </exclusions>
+        </dependency>
+
+        <dependency>
+            <groupId>org.assertj</groupId>
+            <artifactId>assertj-core</artifactId>
+            <version>3.25.3</version>
+            <scope>test</scope>
         </dependency>
 
 

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/JavaGenerationService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/service/JavaGenerationService.java
@@ -1,6 +1,9 @@
 package org.shark.renovatio.provider.cobol.service;
 
 import com.squareup.javapoet.*;
+import org.shark.renovatio.cobol.ir.model.CobolIntermediateModel;
+import org.shark.renovatio.provider.cobol.translation.CobolIntermediateModelService;
+import org.shark.renovatio.provider.cobol.translation.CobolSemanticTranspiler;
 import org.shark.renovatio.shared.domain.StubResult;
 import org.shark.renovatio.shared.domain.Workspace;
 import org.shark.renovatio.shared.nql.NqlQuery;
@@ -8,6 +11,7 @@ import org.springframework.stereotype.Service;
 
 import javax.lang.model.element.Modifier;
 import java.math.BigDecimal;
+import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.HashMap;
@@ -24,10 +28,17 @@ public class JavaGenerationService {
 
     private final CobolParsingService parsingService;
     private final TemplateCodeGenerationService templateService;
+    private final CobolIntermediateModelService intermediateModelService;
+    private final CobolSemanticTranspiler semanticTranspiler;
 
-    public JavaGenerationService(CobolParsingService parsingService, TemplateCodeGenerationService templateService) {
+    public JavaGenerationService(CobolParsingService parsingService,
+                                 TemplateCodeGenerationService templateService,
+                                 CobolIntermediateModelService intermediateModelService,
+                                 CobolSemanticTranspiler semanticTranspiler) {
         this.parsingService = parsingService;
         this.templateService = templateService;
+        this.intermediateModelService = intermediateModelService;
+        this.semanticTranspiler = semanticTranspiler;
     }
 
     /**
@@ -65,7 +76,9 @@ public class JavaGenerationService {
                     String serviceInterface = generateServiceInterface(classBase, metadata);
                     generatedFiles.put(classBase + "Service.java", serviceInterface);
                     // Generate implementation template
+                    CobolIntermediateModel model = resolveIntermediateModel(metadata);
                     String serviceImpl = generateServiceImplementation(classBase, metadata);
+                    serviceImpl = semanticTranspiler.enrichServiceImplementation(serviceImpl, model);
                     generatedFiles.put(classBase + "ServiceImpl.java", serviceImpl);
 
                     @SuppressWarnings("unchecked")
@@ -248,6 +261,24 @@ public class JavaGenerationService {
                 .build();
 
         return javaFile.toString();
+    }
+
+    private CobolIntermediateModel resolveIntermediateModel(Map<String, Object> metadata) {
+        if (metadata == null) {
+            return null;
+        }
+        Object sourcePath = metadata.get("filePath");
+        if (sourcePath instanceof String pathStr && !pathStr.isBlank()) {
+            Path path = Paths.get(pathStr);
+            if (Files.exists(path)) {
+                return intermediateModelService.parse(path);
+            }
+        }
+        Object rawSource = metadata.get("source");
+        if (rawSource instanceof String source && !source.isBlank()) {
+            return intermediateModelService.parse(source);
+        }
+        return null;
     }
 
     /**

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/translation/CobolIntermediateModelService.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/translation/CobolIntermediateModelService.java
@@ -1,0 +1,34 @@
+package org.shark.renovatio.provider.cobol.translation;
+
+import org.shark.renovatio.cobol.ir.model.CobolIntermediateModel;
+import org.shark.renovatio.cobol.ir.parser.SimpleCobolIrParser;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Component
+public class CobolIntermediateModelService {
+
+    private final SimpleCobolIrParser parser;
+
+    public CobolIntermediateModelService() {
+        this(new SimpleCobolIrParser());
+    }
+
+    public CobolIntermediateModelService(SimpleCobolIrParser parser) {
+        this.parser = parser;
+    }
+
+    public CobolIntermediateModel parse(Path cobolFile) {
+        try {
+            return parser.parse(cobolFile);
+        } catch (IOException ex) {
+            throw new IllegalStateException("Failed to parse COBOL file " + cobolFile, ex);
+        }
+    }
+
+    public CobolIntermediateModel parse(String cobolSource) {
+        return parser.parse(cobolSource);
+    }
+}

--- a/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/translation/CobolSemanticTranspiler.java
+++ b/renovatio-provider-cobol/src/main/java/org/shark/renovatio/provider/cobol/translation/CobolSemanticTranspiler.java
@@ -1,0 +1,47 @@
+package org.shark.renovatio.provider.cobol.translation;
+
+import org.openrewrite.ExecutionContext;
+import org.openrewrite.InMemoryExecutionContext;
+import org.openrewrite.Result;
+import org.openrewrite.SourceFile;
+import org.openrewrite.java.JavaParser;
+import org.openrewrite.java.tree.J;
+import org.shark.renovatio.cobol.ir.model.CobolIntermediateModel;
+import org.shark.renovatio.cobol.recipes.PopulateCobolProcessRecipe;
+import org.shark.renovatio.provider.java.OpenRewriteRunResult;
+import org.shark.renovatio.provider.java.OpenRewriteRunner;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+public class CobolSemanticTranspiler {
+
+    private final OpenRewriteRunner runner;
+
+    public CobolSemanticTranspiler(OpenRewriteRunner runner) {
+        this.runner = runner;
+    }
+
+    public String enrichServiceImplementation(String javaSource, CobolIntermediateModel model) {
+        if (javaSource == null || javaSource.isBlank() || model == null) {
+            return javaSource;
+        }
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        ctx.putMessage(PopulateCobolProcessRecipe.CONTEXT_KEY, model);
+
+        JavaParser javaParser = JavaParser.fromJavaVersion()
+                .logCompilationWarningsAndErrors(false)
+                .build();
+        List<J.CompilationUnit> units = javaParser.parse(ctx, javaSource);
+        List<SourceFile> sources = new ArrayList<>(units);
+
+        OpenRewriteRunResult runResult = runner.runRecipe(new PopulateCobolProcessRecipe(), ctx, sources);
+        if (!runResult.getValidationErrors().isEmpty() || runResult.getResults().isEmpty()) {
+            return javaSource;
+        }
+        Result first = runResult.getResults().get(0);
+        return first.getAfter() != null ? first.getAfter().printAll() : javaSource;
+    }
+}

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/translation/CobolSemanticTranspilerTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/translation/CobolSemanticTranspilerTest.java
@@ -1,0 +1,50 @@
+package org.shark.renovatio.provider.cobol.translation;
+
+import org.junit.jupiter.api.Test;
+import org.shark.renovatio.cobol.ir.model.CobolIntermediateModel;
+import org.shark.renovatio.provider.java.OpenRewriteRunner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CobolSemanticTranspilerTest {
+
+    private static final String COBOL_SAMPLE = """
+            IDENTIFICATION DIVISION.
+            PROGRAM-ID. SAMPLE1.
+            DATA DIVISION.
+            WORKING-STORAGE SECTION.
+            01 CUSTOMER-NAME PIC X(30).
+            01 CUSTOMER-RATING PIC 9(2).
+            PROCEDURE DIVISION.
+            MAIN-PARA.
+                MOVE 'JOHN' TO CUSTOMER-NAME.
+            END-PARA.
+            """;
+
+    private static final String JAVA_STUB = """
+            package sample;
+            public class SampleDto {
+                private String customerName;
+                public String getCustomerName() { return customerName; }
+                public void setCustomerName(String customerName) { this.customerName = customerName; }
+                public Integer getCustomerRating() { return 0; }
+            }
+            public class SampleService {
+                public SampleDto process(SampleDto input) {
+                    // TODO: Implement COBOL business logic
+                    SampleDto output = new SampleDto();
+                    return output;
+                }
+            }
+            """;
+
+    @Test
+    void shouldEnrichServiceImplementation() {
+        CobolIntermediateModelService modelService = new CobolIntermediateModelService();
+        CobolIntermediateModel model = modelService.parse(COBOL_SAMPLE);
+        CobolSemanticTranspiler transpiler = new CobolSemanticTranspiler(new OpenRewriteRunner());
+
+        String enriched = transpiler.enrichServiceImplementation(JAVA_STUB, model);
+        assertThat(enriched).contains("output.setCustomerName('JOHN');");
+    }
+}

--- a/rewrite.yml
+++ b/rewrite.yml
@@ -3,4 +3,4 @@ name: com.example.hexagonal.RewriteRecipes
 recipeList:
   - org.openrewrite.java.format.AutoFormat
   - org.openrewrite.java.search.HasMinimumJavaVersion:
-      version: '11'
+      version: '17'


### PR DESCRIPTION
## Summary
- add the new `renovatio-cobol-ir` module with an intermediate model, lightweight parser, and supporting context utilities for COBOL programs
- introduce the `cobol-openrewrite-recipes` module and a PopulateCobolProcessRecipe that converts COBOL IR statements into Java method bodies while enforcing Java 17
- wire the semantic translation pipeline into the COBOL generator, add integration tests, and document the new modules and rewrite configuration

## Testing
- `mvn -pl renovatio-cobol-ir,cobol-openrewrite-recipes,renovatio-provider-cobol test` *(fails: blocked from downloading the Spring Boot parent POM in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e96dba6eac832e9aaf507b15876d1d