### PR TITLE
Improve COBOL semantic translation coverage

### DIFF
--- a/PLAN-TRADUCCION-COBOL-JAVA.md
+++ b/PLAN-TRADUCCION-COBOL-JAVA.md
@@ -28,7 +28,7 @@ Construir una canalización que transforme la **semántica** de los párrafos CO
 1. **Recipes OpenRewrite personalizadas**: definir un módulo `cobol-openrewrite-recipes` donde cada nodo del IR se materialice como una `Recipe` de OpenRewrite que parte del stub generado y lo enriquece con la lógica real (por ejemplo `CobolPerformRecipe`, `CobolEvaluateRecipe`). Estas recetas deberán construir o modificar `J.MethodDeclaration`, `J.If`, `J.Switch`, etc., para garantizar un AST Java válido.
 2. **Infraestructura compartida**: reutilizar directamente `OpenRewriteRunner` y el ciclo de ejecución existente (`JavaRecipeExecutor`) para aplicar las nuevas recetas a los servicios generados, asegurando la misma interfaz MCP (`preview/apply`, métricas, validaciones de seguridad).【F:renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/OpenRewriteRunner.java†L12-L132】【F:renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/execution/JavaRecipeExecutor.java†L23-L169】
 3. **Descubrimiento y composición**: registrar las recetas COBOL en `OpenRewriteRecipeDiscoveryService` para exponerlas como herramientas MCP al igual que las de Java, aprovechando la activación dinámica, validaciones y marcado de recetas inseguras.【F:renovatio-provider-java/src/main/java/org/shark/renovatio/provider/java/discovery/OpenRewriteRecipeDiscoveryService.java†L22-L158】
-4. **Conversión de tipos y estado**: mantener una tabla `PIC` → tipos Java y un contexto de ejecución (`CobolExecutionContext`) que puedan inyectarse a las recetas para generar atributos, DTOs y parámetros adecuados.
+4. **Conversión de tipos y estado**: mantener una tabla `PIC` → tipos Java y un contexto de ejecución (`CobolExecutionContext`) que puedan inyectarse a las recetas para generar atributos, DTOs y parámetros adecuados. Integrar librerías de binding como **JRecord** (copybooks → POJOs/records) y **LegStar** (serialización COBOL ↔ Java) para garantizar que las recetas operen con metadata real sin romper el contrato de `Recipe`/`JavaIsoVisitor` definido por OpenRewrite.
 5. **Soporte DB2/archivos**:
    - Incluir recetas específicas para construir repositorios Spring Data/JDBC a partir de metadata COBOL.
    - Generar adaptadores de I/O mediante recetas que creen componentes Spring (`@Repository`, `@Component`) con la configuración necesaria.
@@ -80,8 +80,10 @@ Construir una canalización que transforme la **semántica** de los párrafos CO
 - **ProLeap** o **Koopa**: parsing COBOL y obtención de AST detallado.
 - **OpenRewrite** + **JavaPoet**: generación y refactorización de código Java.
 - **MapStruct**: mapeo automático de DTO ↔ estructuras COBOL.
+- **JRecord**: lectura de copybooks, mapping `PIC` ↔ tipos Java y generación de POJOs.
+- **LegStar**: binding COBOL ↔ Java y soporte para CICS/IMS.
 - **jOOQ** / **Spring Data JDBC**: traducción de sentencias DB2 a repositorios Java.
-- **LegStar** / **Spring Integration**: integración con CICS, MQ y servicios externos.
+- **Spring Integration** / **Apache Camel**: integración con MQ, colas y servicios externos.
 - **GnuCOBOL** (en pipelines CI) para validar resultados ejecutando el programa original.
 - **ANTLR** (opcional) para reglas específicas cuando ProLeap no cubra ciertas extensiones.
 

--- a/cobol-openrewrite-recipes/src/main/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipe.java
+++ b/cobol-openrewrite-recipes/src/main/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipe.java
@@ -12,8 +12,10 @@ import org.shark.renovatio.cobol.ir.model.*;
 
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
+import java.util.Set;
 
 public class PopulateCobolProcessRecipe extends org.openrewrite.Recipe {
 
@@ -86,7 +88,7 @@ public class PopulateCobolProcessRecipe extends org.openrewrite.Recipe {
                 paragraph = model.getEntryParagraph();
             }
             
-            List<String> rendered = renderParagraph(paragraph);
+            List<String> rendered = renderParagraph(paragraph, model);
             if (rendered.isEmpty()) {
                 return method;
             }
@@ -133,59 +135,84 @@ public class PopulateCobolProcessRecipe extends org.openrewrite.Recipe {
                 .anyMatch(text -> text != null && text.contains("TODO"));
     }
 
-    private List<String> renderParagraph(CobolParagraph paragraph) {
-        List<String> lines = new ArrayList<>();
-        for (CobolStatement statement : paragraph.getStatements()) {
-            if (statement instanceof MoveStatement move) {
-                lines.add(renderMove(move));
-                continue;
-            }
-            if (statement instanceof ComputeStatement compute) {
-                lines.add(renderCompute(compute));
-                continue;
-            }
-            if (statement instanceof IfStatement ifStatement) {
-                lines.addAll(renderIf(ifStatement));
-                continue;
-            }
-            if (statement instanceof PerformStatement perform) {
-                lines.add(renderPerform(perform));
-                continue;
-            }
-            if (statement instanceof Db2Statement db2) {
-                lines.add(renderDb2(db2));
-            }
-        }
-        return lines;
+    private List<String> renderParagraph(CobolParagraph paragraph, CobolIntermediateModel model) {
+        return renderParagraph(paragraph, model, new LinkedHashSet<>());
     }
 
-    private List<String> renderIf(IfStatement ifStatement) {
+    private List<String> renderParagraph(CobolParagraph paragraph,
+                                         CobolIntermediateModel model,
+                                         Set<String> visitedParagraphs) {
+        if (paragraph == null) {
+            return List.of();
+        }
+
+        String upperName = paragraph.getName().toUpperCase(Locale.ROOT);
+        if (!visitedParagraphs.add(upperName)) {
+            return List.of(String.format(Locale.ROOT,
+                    "// Recursive PERFORM of paragraph %s detected, skipping expansion", upperName));
+        }
+
+        try {
+            List<String> lines = new ArrayList<>();
+            for (CobolStatement statement : paragraph.getStatements()) {
+                lines.addAll(renderStatement(statement, model, visitedParagraphs));
+            }
+            return lines;
+        } finally {
+            visitedParagraphs.remove(upperName);
+        }
+    }
+
+    private List<String> renderStatement(CobolStatement statement,
+                                         CobolIntermediateModel model,
+                                         Set<String> visitedParagraphs) {
+        if (statement instanceof MoveStatement move) {
+            return List.of(renderMove(move));
+        }
+        if (statement instanceof ComputeStatement compute) {
+            return List.of(renderCompute(compute));
+        }
+        if (statement instanceof IfStatement ifStatement) {
+            return renderIf(ifStatement, model, visitedParagraphs);
+        }
+        if (statement instanceof PerformStatement perform) {
+            return renderPerform(perform, model, visitedParagraphs);
+        }
+        if (statement instanceof EvaluateStatement evaluate) {
+            return renderEvaluate(evaluate, model, visitedParagraphs);
+        }
+        if (statement instanceof Db2Statement db2) {
+            return List.of(renderDb2(db2));
+        }
+        if (statement instanceof CallStatement call) {
+            return List.of(renderCall(call));
+        }
+        if (statement instanceof FileOperationStatement fileOp) {
+            return List.of(renderFileOperation(fileOp));
+        }
+        return List.of("// Unhandled COBOL statement");
+    }
+
+    private List<String> renderIf(IfStatement ifStatement,
+                                  CobolIntermediateModel model,
+                                  Set<String> visitedParagraphs) {
         List<String> lines = new ArrayList<>();
         lines.add(String.format(Locale.ROOT, "if (%s) {", translateCondition(ifStatement.getCondition())));
         for (CobolStatement stmt : ifStatement.getThenStatements()) {
-            lines.add(indent(renderSingle(stmt)));
+            for (String rendered : renderStatement(stmt, model, visitedParagraphs)) {
+                lines.add(indent(rendered));
+            }
         }
         if (!ifStatement.getElseStatements().isEmpty()) {
             lines.add("} else {");
             for (CobolStatement stmt : ifStatement.getElseStatements()) {
-                lines.add(indent(renderSingle(stmt)));
+                for (String rendered : renderStatement(stmt, model, visitedParagraphs)) {
+                    lines.add(indent(rendered));
+                }
             }
         }
         lines.add("}");
         return lines;
-    }
-
-    private String renderSingle(CobolStatement statement) {
-        if (statement instanceof MoveStatement move) {
-            return renderMove(move);
-        }
-        if (statement instanceof ComputeStatement compute) {
-            return renderCompute(compute);
-        }
-        if (statement instanceof Db2Statement db2) {
-            return renderDb2(db2);
-        }
-        return "// Unhandled COBOL statement";
     }
 
     private String renderMove(MoveStatement move) {
@@ -198,12 +225,71 @@ public class PopulateCobolProcessRecipe extends org.openrewrite.Recipe {
                 toSetter(compute.getTarget()), translateExpression(compute.getExpression()));
     }
 
-    private String renderPerform(PerformStatement perform) {
-        return String.format(Locale.ROOT, "// TODO: PERFORM %s", perform.getParagraph());
+    private List<String> renderPerform(PerformStatement perform,
+                                       CobolIntermediateModel model,
+                                       Set<String> visitedParagraphs) {
+        List<String> lines = new ArrayList<>();
+        if (perform.getParagraph() == null || perform.getParagraph().isBlank()) {
+            lines.add("// PERFORM with unnamed paragraph");
+            return lines;
+        }
+
+        model.findParagraph(perform.getParagraph()).ifPresentOrElse(target -> {
+            List<String> nested = renderParagraph(target, model, new LinkedHashSet<>(visitedParagraphs));
+            if (nested.isEmpty()) {
+                lines.add(String.format(Locale.ROOT,
+                        "// PERFORM %s (paragraph is empty)", perform.getParagraph()));
+            } else {
+                lines.addAll(nested);
+            }
+        }, () -> lines.add(String.format(Locale.ROOT,
+                "// PERFORM %s (paragraph not found)", perform.getParagraph())));
+
+        if (perform.getThroughParagraph() != null) {
+            lines.add(String.format(Locale.ROOT,
+                    "// PERFORM THRU %s not yet expanded", perform.getThroughParagraph()));
+        }
+        return lines;
+    }
+
+    private List<String> renderEvaluate(EvaluateStatement evaluate,
+                                        CobolIntermediateModel model,
+                                        Set<String> visitedParagraphs) {
+        List<String> lines = new ArrayList<>();
+        String selector = toJavaExpression(evaluate.getExpression());
+        lines.add(String.format(Locale.ROOT, "switch (%s) {", selector));
+        for (EvaluateStatement.EvaluateWhenBranch branch : evaluate.getBranches()) {
+            String label = branch.getCondition().equalsIgnoreCase("OTHER")
+                    ? "default"
+                    : "case " + toJavaExpression(branch.getCondition());
+            lines.add(indent(label + " -> {"));
+            for (CobolStatement stmt : branch.getStatements()) {
+                for (String rendered : renderStatement(stmt, model, visitedParagraphs)) {
+                    lines.add(indent(indent(rendered)));
+                }
+            }
+            lines.add(indent("}"));
+        }
+        lines.add("}");
+        return lines;
     }
 
     private String renderDb2(Db2Statement db2) {
         return String.format(Locale.ROOT, "// EXEC SQL %s", db2.getSql());
+    }
+
+    private String renderCall(CallStatement call) {
+        StringBuilder builder = new StringBuilder();
+        builder.append("// CALL ").append(call.getTarget());
+        if (!call.getArguments().isEmpty()) {
+            builder.append(" USING ")
+                    .append(String.join(", ", call.getArguments()));
+        }
+        return builder.toString();
+    }
+
+    private String renderFileOperation(FileOperationStatement fileOp) {
+        return String.format(Locale.ROOT, "// %s %s", fileOp.getOperationType(), fileOp.getFileName());
     }
 
     private String translateCondition(String condition) {

--- a/cobol-openrewrite-recipes/src/test/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipeTest.java
+++ b/cobol-openrewrite-recipes/src/test/java/org/shark/renovatio/cobol/recipes/PopulateCobolProcessRecipeTest.java
@@ -24,13 +24,23 @@ class PopulateCobolProcessRecipeTest {
             01 CUSTOMER-RATING PIC 9(2).
             PROCEDURE DIVISION.
             MAIN-PARA.
+                PERFORM PREP-PARA.
                 MOVE 'JOHN' TO CUSTOMER-NAME.
                 IF CUSTOMER-RATING > 80
                     MOVE 'VIP' TO CUSTOMER-NAME
                 ELSE
                     MOVE 'STANDARD' TO CUSTOMER-NAME
                 END-IF.
+                EVALUATE CUSTOMER-RATING
+                    WHEN 1
+                        MOVE 'BRONZE' TO CUSTOMER-NAME
+                    WHEN OTHER
+                        MOVE 'PLATINUM' TO CUSTOMER-NAME
+                END-EVALUATE.
                 GOBACK.
+            END-PARA.
+            PREP-PARA.
+                MOVE 'INIT' TO CUSTOMER-NAME.
             END-PARA.
             """;
 
@@ -67,6 +77,61 @@ class PopulateCobolProcessRecipeTest {
         String updated = results.get(0).getAfter().printAll();
         assertThat(updated).contains("output.setCustomerName(\"JOHN\");");
         assertThat(updated).contains("if (input.getCustomerRating() > 80)");
+        assertThat(updated).contains("switch (input.getCustomerRating()) {");
+        assertThat(updated).contains("case 1 -> {");
+        assertThat(updated).contains("output.setCustomerName(\"BRONZE\");");
+        assertThat(updated).contains("output.setCustomerName(\"PLATINUM\");");
         assertThat(updated).doesNotContain("TODO");
+    }
+
+    @Test
+    void shouldInlinePerformParagraphs() {
+        String cobol = """
+                IDENTIFICATION DIVISION.
+                PROGRAM-ID. SAMPLE2.
+                DATA DIVISION.
+                WORKING-STORAGE SECTION.
+                01 CUSTOMER-NAME PIC X(30).
+                PROCEDURE DIVISION.
+                MAIN-PARA.
+                    PERFORM PREP-PARA.
+                    MOVE 'READY' TO CUSTOMER-NAME.
+                    GOBACK.
+                PREP-PARA.
+                    MOVE 'INIT' TO CUSTOMER-NAME.
+                    GOBACK.
+                """;
+
+        SimpleCobolIrParser parser = new SimpleCobolIrParser();
+        CobolIntermediateModel model = parser.parse(cobol);
+
+        String javaSource = """
+                package sample;
+                public class SampleService {
+                    public SampleDto process(SampleDto input) {
+                        // TODO: Implement COBOL business logic
+                        SampleDto output = new SampleDto();
+                        return output;
+                    }
+                }
+                """;
+
+        JavaParser javaParser = JavaParser.fromJavaVersion().build();
+        ExecutionContext ctx = new InMemoryExecutionContext(Throwable::printStackTrace);
+        ctx.putMessage(PopulateCobolProcessRecipe.CONTEXT_KEY, model);
+
+        List<org.openrewrite.SourceFile> sources = javaParser.parse(ctx, javaSource)
+                .collect(java.util.stream.Collectors.toList());
+        PopulateCobolProcessRecipe recipe = new PopulateCobolProcessRecipe();
+
+        org.openrewrite.LargeSourceSet lss = new org.openrewrite.internal.InMemoryLargeSourceSet(sources);
+        var run = recipe.run(lss, ctx);
+        List<Result> results = run.getChangeset().getAllResults();
+
+        assertThat(results).hasSize(1);
+        String updated = results.get(0).getAfter().printAll();
+        assertThat(updated).contains("output.setCustomerName(\"INIT\");");
+        assertThat(updated).contains("output.setCustomerName(\"READY\");");
+        assertThat(updated).doesNotContain("PERFORM");
     }
 }

--- a/docs/cobol-java-mapping-investigacion.md
+++ b/docs/cobol-java-mapping-investigacion.md
@@ -1,0 +1,43 @@
+# Investigación sobre librerías y frameworks para mapear COBOL → Java
+
+Este documento resume alternativas para implementar la traducción de primitivas, estructuras de datos y rutinas COBOL hacia código Java funcional, manteniendo el esquema de interfaces ya disponible en Renovatio (basado en OpenRewrite + servicios Spring generados).
+
+## 1. Requerimientos clave
+
+- **Cobertura de tipos básicos**: soportar `PIC` (alfanuméricos, numéricos, zoned, packed) y cláusulas `REDEFINES`, `OCCURS`, `COMP-*`.
+- **Conversión de rutinas comunes**: sentencias `MOVE`, `COMPUTE`, `STRING/UNSTRING`, evaluaciones `IF/EVALUATE`, `PERFORM`.
+- **Integración con OpenRewrite**: exponer la lógica de conversión como `Recipe`/`Visitor` para inyectar código Java dentro de los stubs generados.
+- **Generación de DTOs y servicios**: producir POJOs/records, mappers y servicios Spring con lógica real, reemplazando los `@TODO` actuales.
+
+## 2. Librerías y frameworks relevantes
+
+| Herramienta | Tipo | Aportes para la migración | Observaciones |
+|-------------|------|---------------------------|---------------|
+| **JRecord** | Open Source (Apache 2.0) | Lee copybooks COBOL, genera POJOs Java y provee conversiones `PIC` ↔ tipos Java, incluyendo packed/comp-3. Útil para mapear la división `DATA` a DTOs reutilizables desde OpenRewrite. | Integración directa posible: el IR COBOL puede usar JRecord para resolver metadata y la receta Java generar clases con el mismo layout. |
+| **LegStar** | Open Source (LGPL) | Toolkit para binding Java ↔ COBOL (incluye generador `cob2j`), serialización/deserialización de estructuras y runtime para CICS/IMS. | Permite generar clases Java a partir de copybooks y manejar conversiones de carácter/decimal. Se puede invocar durante la fase de generación y envolver la lógica dentro de recetas OpenRewrite. |
+| **OpenLegacy** | Comercial con componentes OSS | Plataforma de modernización que expone programas COBOL como servicios Java/REST generados. | Referencia arquitectónica: sugiere pipelines donde un parser produce modelos y se inyectan en plantillas. Podemos replicar el patrón con OpenRewrite y nuestro IR. |
+| **Heirloom Platform** | Comercial | Traduce COBOL a Java gestionando runtime y tipos. | Inspiración sobre cómo mapear instrucciones (`PERFORM`, `CALL`). No reutilizable directamente, pero valida la viabilidad técnica del mapeo completo. |
+| **Raincode COBOL Compiler** | Comercial | Compila COBOL a .NET/Java conservando semántica. | Otra referencia sobre el alcance que debe cubrir el motor de traducción. |
+| **Micro Focus Enterprise COBOL + JVM** | Comercial | Ofrece generación de bytecode Java y API de interoperabilidad. | Puede aportar guías de conversión de tipos (`PIC` → `BigDecimal`, `String`). |
+
+## 3. Cómo integrar estas soluciones con OpenRewrite
+
+1. **Normalización con IR**: continuar con `renovatio-cobol-ir` para representar nodos semánticos. Aprovechar JRecord/LegStar para resolver tipos antes de generar AST Java.
+2. **Recetas específicas**: crear recetas en `cobol-openrewrite-recipes` como `CobolDataDivisionRecipe`, `CobolPerformRecipe`, `CobolEvaluateRecipe`. Cada receta implementa `Recipe` y usa `JavaIsoVisitor` para insertar o modificar `J.MethodDeclaration`, `J.If`, `J.Block` respetando el esquema MCP existente (`preview/apply`).
+3. **Inyección de mappers**: con MapStruct (ya en el stack) generar interfaces `@Mapper` que traduzcan las estructuras JRecord/LegStar a DTOs y viceversa, y referenciarlas desde las recetas mediante plantillas JavaPoet o `Template` de OpenRewrite.
+4. **Servicios funcionales**: reemplazar los `@TODO` mediante la composición de recetas que ensamblen la lógica (por ejemplo, `CobolPerformRecipe` crea métodos privados por párrafo COBOL y `CobolServiceAssemblerRecipe` conecta esos métodos en el `process`).
+
+## 4. Consideraciones adicionales
+
+- **Compatibilidad de licencias**: JRecord (Apache) y LegStar (LGPL) son integrables; las soluciones comerciales pueden servir como guía, pero no se pueden distribuir dentro del repositorio.
+- **Pruebas**: generar pruebas JUnit apoyadas en datos de ejemplo (`copybooks` + `flat files`) usando JRecord para validar la equivalencia entre COBOL y Java.
+- **Ejecución en pipelines**: integrar el flujo dentro del actual `OpenRewriteRunner` para mantener métricas, dry-runs (`preview`) y capacidad MCP.
+
+## 5. Próximos pasos propuestos
+
+1. Prototipo con JRecord para convertir copybooks a POJOs y verificar el mapping de tipos numéricos/packed.
+2. Exponer el prototipo como receta OpenRewrite que inyecta DTOs y métodos en un servicio generado.
+3. Evaluar LegStar para llamadas externas (CICS/IMS) y para ampliar la cobertura de conversiones.
+4. Documentar el contrato MCP para recetas COBOL (`tools/list`, `tools/describe`) asegurando compatibilidad con los ejecutores actuales.
+
+Esta estrategia permite cubrir las primitivas y rutinas COBOL con código Java real y reutilizable, manteniendo la arquitectura basada en OpenRewrite.

--- a/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/translation/CobolSemanticTranspilerTest.java
+++ b/renovatio-provider-cobol/src/test/java/org/shark/renovatio/provider/cobol/translation/CobolSemanticTranspilerTest.java
@@ -45,6 +45,6 @@ class CobolSemanticTranspilerTest {
         CobolSemanticTranspiler transpiler = new CobolSemanticTranspiler(new OpenRewriteRunner());
 
         String enriched = transpiler.enrichServiceImplementation(JAVA_STUB, model);
-        assertThat(enriched).contains("output.setCustomerName('JOHN');");
+        assertThat(enriched).contains("output.setCustomerName(\"JOHN\");");
     }
 }


### PR DESCRIPTION
## Summary
- inline COBOL PERFORM paragraphs and translate EVALUATE/DB2/Call/File statements when enriching generated service methods
- extend the PopulateCobolProcessRecipe tests to assert evaluation branches and paragraph inlining, and align the semantic transpiler expectation with the generated Java

## Testing
- mvn -pl cobol-openrewrite-recipes -am test *(fails: Non-resolvable parent POM org.springframework.boot:spring-boot-starter-parent:3.2.5 due to 403 from Maven Central)*

------
https://chatgpt.com/codex/tasks/task_e_68e9854c7474832ebbacd197eb3ee112